### PR TITLE
fix backup removal

### DIFF
--- a/gris/api/backup/google_shared_drive.py
+++ b/gris/api/backup/google_shared_drive.py
@@ -96,7 +96,20 @@ def run_daily_backup():
 			)
 			uploaded_files.append(uploaded)
 
-		deleted_count = _apply_retention_policy(drive, settings)
+		retention_summary = _new_retention_summary()
+		try:
+			retention_summary = _apply_retention_policy(drive, settings)
+		except Exception:
+			retention_summary["warning"] = _(
+				"Retencao nao foi concluida. Verifique Error Log para detalhes."
+			)
+			retention_traceback = frappe.get_traceback()
+			frappe.log_error(retention_traceback, "Shared Drive Retention Failure")
+			logger.warning(
+				"Retencao com falha no Shared Drive. site=%s warning=%s",
+				frappe.local.site,
+				retention_summary["warning"],
+			)
 
 		frappe.db.set_single_value(
 			SETTINGS_DOCTYPE,
@@ -108,18 +121,34 @@ def run_daily_backup():
 		frappe.db.commit()
 
 		logger.info(
-			"Backup concluido no Shared Drive. site=%s snapshot=%s uploaded=%s deleted=%s",
+			"Backup concluido no Shared Drive. site=%s snapshot=%s uploaded=%s deleted=%s already_missing=%s retention_failed=%s",
 			frappe.local.site,
 			snapshot_folder["name"],
 			len(uploaded_files),
-			deleted_count,
+			retention_summary["deleted_count"],
+			retention_summary["already_missing_count"],
+			retention_summary["failed_count"],
 		)
+
+		notification_message = _(
+			"Backup concluido com sucesso. Snapshot: {0}. Arquivos enviados: {1}. "
+			"Snapshots removidos por retencao: {2}. Snapshots ja ausentes: {3}. "
+			"Falhas na retencao: {4}."
+		).format(
+			snapshot_folder["name"],
+			len(uploaded_files),
+			retention_summary["deleted_count"],
+			retention_summary["already_missing_count"],
+			retention_summary["failed_count"],
+		)
+
+		if retention_summary.get("warning"):
+			notification_message = f"{notification_message} {retention_summary['warning']}"
+
 		_send_notification(
 			settings,
 			success=True,
-			message=_(
-				"Backup concluido com sucesso. Snapshot: {0}. Arquivos enviados: {1}. Snapshots removidos por retencao: {2}."
-			).format(snapshot_folder["name"], len(uploaded_files), deleted_count),
+			message=notification_message,
 		)
 	except Exception:
 		error_message = frappe.get_traceback()
@@ -264,7 +293,8 @@ def _upload_file_to_shared_drive(drive, settings, backup_path, parent_folder_id)
 def _apply_retention_policy(drive, settings):
 	cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=settings.retention_days)
 	page_token = None
-	deleted = 0
+	summary = _new_retention_summary()
+	logger = frappe.logger("shared_drive_backup")
 
 	while True:
 		params = {
@@ -293,16 +323,102 @@ def _apply_retention_policy(drive, settings):
 			if not created_time or created_time >= cutoff:
 				continue
 
-			_execute_with_retry(
-				lambda fid=file_info["id"]: drive.files().delete(fileId=fid, supportsAllDrives=True).execute()
+			delete_result = _delete_snapshot_folder(drive, file_info)
+			if delete_result["status"] == "deleted":
+				summary["deleted_count"] += 1
+				continue
+
+			if delete_result["status"] == "already_missing":
+				summary["already_missing_count"] += 1
+				logger.info(
+					"Snapshot de retencao ja ausente no Shared Drive. site=%s snapshot=%s id=%s",
+					frappe.local.site,
+					file_info.get("name"),
+					file_info.get("id"),
+				)
+				continue
+
+			summary["failed_count"] += 1
+			summary["failures"].append(
+				{
+					"folder_id": file_info.get("id"),
+					"folder_name": file_info.get("name"),
+					"status_code": delete_result.get("status_code"),
+				}
 			)
-			deleted += 1
+			logger.warning(
+				"Falha ao remover snapshot de retencao. site=%s snapshot=%s id=%s status=%s",
+				frappe.local.site,
+				file_info.get("name"),
+				file_info.get("id"),
+				delete_result.get("status_code"),
+			)
 
 		page_token = response.get("nextPageToken")
 		if not page_token:
 			break
 
-	return deleted
+	summary["warning"] = _build_retention_warning(summary)
+	return summary
+
+
+def _delete_snapshot_folder(drive, file_info):
+	folder_id = file_info.get("id")
+	if not folder_id:
+		return {
+			"status": "failed",
+			"status_code": None,
+		}
+
+	try:
+		_execute_with_retry(
+			lambda fid=folder_id: drive.files().delete(fileId=fid, supportsAllDrives=True).execute()
+		)
+		return {
+			"status": "deleted",
+			"status_code": None,
+		}
+	except HttpError as exc:
+		status_code = _get_http_status_code(exc)
+		if status_code == 404:
+			return {
+				"status": "already_missing",
+				"status_code": status_code,
+			}
+
+		return {
+			"status": "failed",
+			"status_code": status_code,
+		}
+	except Exception:
+		return {
+			"status": "failed",
+			"status_code": None,
+		}
+
+
+def _new_retention_summary():
+	return {
+		"deleted_count": 0,
+		"already_missing_count": 0,
+		"failed_count": 0,
+		"failures": [],
+		"warning": "",
+	}
+
+
+def _build_retention_warning(summary):
+	if summary.get("failed_count"):
+		return _(
+			"Retencao executada com avisos. Nao foi possivel remover {0} snapshot(s)."
+		).format(summary["failed_count"])
+
+	if summary.get("already_missing_count"):
+		return _("Retencao encontrou {0} snapshot(s) ja ausente(s).").format(
+			summary["already_missing_count"]
+		)
+
+	return ""
 
 
 def _is_snapshot_folder(folder_name):
@@ -359,11 +475,15 @@ def _execute_with_retry(operation):
 		try:
 			return operation()
 		except HttpError as exc:
-			status_code = getattr(exc, "status_code", None) or getattr(exc.resp, "status", None)
+			status_code = _get_http_status_code(exc)
 			if status_code not in RETRYABLE_STATUS_CODES or attempt == MAX_RETRIES - 1:
 				raise
 
 			time.sleep(2**attempt)
+
+
+def _get_http_status_code(exc):
+	return getattr(exc, "status_code", None) or getattr(exc.resp, "status", None)
 
 
 def _send_notification(settings, success, message):

--- a/gris/api/backup/test_google_shared_drive.py
+++ b/gris/api/backup/test_google_shared_drive.py
@@ -1,0 +1,261 @@
+# Copyright (c) 2026, Grupo Escoteiro Professora Inah de Mello - 47/SP and Contributors
+# See license.txt
+
+import datetime
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from googleapiclient.errors import HttpError
+
+from gris.api.backup import google_shared_drive as backup_module
+
+
+class _DummyHttpResponse:
+	def __init__(self, status_code):
+		self.status = status_code
+		self.reason = "Test"
+
+
+class _FakeRequest:
+	def __init__(self, executor):
+		self._executor = executor
+
+	def execute(self):
+		return self._executor()
+
+
+class _FakeFilesResource:
+	def __init__(self, list_pages, delete_behaviors=None):
+		self.list_pages = list_pages
+		self.delete_behaviors = delete_behaviors or {}
+		self.list_calls = []
+		self.delete_calls = []
+		self._list_index = 0
+
+	def list(self, **kwargs):
+		index = self._list_index
+		self._list_index += 1
+		self.list_calls.append(kwargs)
+
+		return _FakeRequest(
+			lambda: self.list_pages[index]
+			if index < len(self.list_pages)
+			else {"files": [], "nextPageToken": None}
+		)
+
+	def delete(self, fileId, supportsAllDrives=True):
+		self.delete_calls.append(fileId)
+		behavior = self.delete_behaviors.get(fileId, "ok")
+
+		def _execute():
+			if isinstance(behavior, Exception):
+				raise behavior
+
+			if callable(behavior):
+				return behavior()
+
+			return {}
+
+		return _FakeRequest(_execute)
+
+
+class _FakeDrive:
+	def __init__(self, list_pages, delete_behaviors=None):
+		self.files_resource = _FakeFilesResource(list_pages, delete_behaviors)
+
+	def files(self):
+		return self.files_resource
+
+
+class _DummySettings:
+	def __init__(self, retention_days=30, backup_folder_id="BACKUP_ROOT", shared_drive_id=None):
+		self.retention_days = retention_days
+		self.backup_folder_id = backup_folder_id
+		self.shared_drive_id = shared_drive_id
+
+
+class _RunSettings(_DummySettings):
+	def __init__(self):
+		super().__init__()
+		self.enable_backup = 1
+		self.include_public_files = 1
+		self.include_private_files = 1
+		self.notification_email = ""
+		self.notify_on_success = 0
+
+
+def _google_datetime(value):
+	return value.astimezone(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _snapshot(folder_id, created_time):
+	timestamp = created_time.astimezone(datetime.timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
+	return {
+		"id": folder_id,
+		"name": f"{frappe.local.site}-backup-{timestamp}",
+		"createdTime": _google_datetime(created_time),
+		"mimeType": "application/vnd.google-apps.folder",
+	}
+
+
+def _make_http_error(status_code, message):
+	response = _DummyHttpResponse(status_code)
+	content = (
+		"{"
+		f'"error":{{"code":{status_code},"message":"{message}"}}'
+		"}"
+	).encode()
+	return HttpError(response, content, uri="https://www.googleapis.com/drive/v3/files/test")
+
+
+def _patch_module_attr(module, attr_name, replacement, patched_attrs):
+	patched_attrs.append((attr_name, getattr(module, attr_name)))
+	setattr(module, attr_name, replacement)
+
+
+class TestGoogleSharedDriveBackup(FrappeTestCase):
+	def test_retention_deletes_old_snapshot(self):
+		settings = _DummySettings(retention_days=30)
+		old_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=45)
+		drive = _FakeDrive(list_pages=[{"files": [_snapshot("old-1", old_time)], "nextPageToken": None}])
+
+		result = backup_module._apply_retention_policy(drive, settings)
+
+		self.assertEqual(result["deleted_count"], 1)
+		self.assertEqual(result["already_missing_count"], 0)
+		self.assertEqual(result["failed_count"], 0)
+		self.assertEqual(drive.files_resource.delete_calls, ["old-1"])
+
+	def test_retention_treats_404_as_already_missing(self):
+		settings = _DummySettings(retention_days=30)
+		old_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=45)
+		drive = _FakeDrive(
+			list_pages=[
+				{
+					"files": [
+						_snapshot("old-404", old_time),
+						_snapshot("old-2", old_time),
+					],
+					"nextPageToken": None,
+				}
+			],
+			delete_behaviors={
+				"old-404": _make_http_error(404, "File not found"),
+			},
+		)
+
+		result = backup_module._apply_retention_policy(drive, settings)
+
+		self.assertEqual(result["deleted_count"], 1)
+		self.assertEqual(result["already_missing_count"], 1)
+		self.assertEqual(result["failed_count"], 0)
+		self.assertEqual(drive.files_resource.delete_calls, ["old-404", "old-2"])
+
+	def test_retention_continues_after_non_404_failure(self):
+		settings = _DummySettings(retention_days=30)
+		old_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=45)
+		drive = _FakeDrive(
+			list_pages=[
+				{
+					"files": [
+						_snapshot("old-fail", old_time),
+						_snapshot("old-ok", old_time),
+					],
+					"nextPageToken": None,
+				}
+			],
+			delete_behaviors={
+				"old-fail": _make_http_error(400, "Bad request"),
+			},
+		)
+
+		result = backup_module._apply_retention_policy(drive, settings)
+
+		self.assertEqual(result["deleted_count"], 1)
+		self.assertEqual(result["already_missing_count"], 0)
+		self.assertEqual(result["failed_count"], 1)
+		self.assertEqual(len(result["failures"]), 1)
+		self.assertEqual(result["failures"][0]["folder_id"], "old-fail")
+		self.assertEqual(drive.files_resource.delete_calls, ["old-fail", "old-ok"])
+
+	def test_retention_skips_recent_snapshot(self):
+		settings = _DummySettings(retention_days=30)
+		recent_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=5)
+		drive = _FakeDrive(list_pages=[{"files": [_snapshot("recent-1", recent_time)], "nextPageToken": None}])
+
+		result = backup_module._apply_retention_policy(drive, settings)
+
+		self.assertEqual(result["deleted_count"], 0)
+		self.assertEqual(result["already_missing_count"], 0)
+		self.assertEqual(result["failed_count"], 0)
+		self.assertEqual(drive.files_resource.delete_calls, [])
+
+	def test_run_daily_backup_keeps_success_when_retention_crashes(self):
+		settings = _RunSettings()
+		notification_calls = []
+		db_updates = []
+		logged_errors = []
+		patched_attrs = []
+
+		original_set_single_value = frappe.db.set_single_value
+		original_commit = frappe.db.commit
+		original_log_error = frappe.log_error
+
+		try:
+			_patch_module_attr(backup_module, "_get_settings", lambda: settings, patched_attrs)
+			_patch_module_attr(backup_module, "_validate_settings", lambda current_settings: None, patched_attrs)
+			_patch_module_attr(backup_module, "_get_google_drive_service", lambda: object(), patched_attrs)
+			_patch_module_attr(
+				backup_module,
+				"_validate_destination_folder",
+				lambda drive, current_settings: None,
+				patched_attrs,
+			)
+			_patch_module_attr(
+				backup_module,
+				"_create_snapshot_folder",
+				lambda drive, current_settings: {"id": "snapshot-1", "name": "snapshot-1"},
+				patched_attrs,
+			)
+			_patch_module_attr(backup_module, "_generate_backups", lambda current_settings: ["db.sql.gz"], patched_attrs)
+			_patch_module_attr(
+				backup_module,
+				"_upload_file_to_shared_drive",
+				lambda drive, settings, backup_path, parent_folder_id: {"id": "file-1"},
+				patched_attrs,
+			)
+			_patch_module_attr(
+				backup_module,
+				"_apply_retention_policy",
+				lambda drive, current_settings: (_ for _ in ()).throw(RuntimeError("retention failure")),
+				patched_attrs,
+			)
+			_patch_module_attr(
+				backup_module,
+				"_send_notification",
+				lambda current_settings, success, message: notification_calls.append(
+					{"success": success, "message": message}
+				),
+				patched_attrs,
+			)
+
+			frappe.db.set_single_value = lambda doctype, values: db_updates.append((doctype, values))
+			frappe.db.commit = lambda: None
+			frappe.log_error = lambda *args, **kwargs: logged_errors.append((args, kwargs))
+
+			backup_module.run_daily_backup()
+		finally:
+			for attr_name, original in reversed(patched_attrs):
+				setattr(backup_module, attr_name, original)
+
+			frappe.db.set_single_value = original_set_single_value
+			frappe.db.commit = original_commit
+			frappe.log_error = original_log_error
+
+		self.assertEqual(len(notification_calls), 1)
+		self.assertEqual(notification_calls[0]["success"], True)
+		self.assertIn("Retencao nao foi concluida", notification_calls[0]["message"])
+		self.assertEqual(len(db_updates), 1)
+		self.assertEqual(db_updates[0][0], backup_module.SETTINGS_DOCTYPE)
+		self.assertEqual(db_updates[0][1]["last_error"], "")
+		self.assertEqual(len(logged_errors), 1)


### PR DESCRIPTION
This pull request significantly improves the Google Shared Drive backup retention logic and its test coverage. The main changes include enhanced error handling and reporting for retention policy execution, more detailed notification messages, and the addition of comprehensive unit tests for retention scenarios.

**Improvements to retention policy logic:**

* The retention policy (`_apply_retention_policy`) now returns a detailed summary of results, including counts of deleted, already-missing, and failed snapshot deletions, along with failure details and warnings. Previously, only the deleted count was returned. [[1]](diffhunk://#diff-cec9a6cf2d86f17c13659a5f547f9b0479b4f3a52fccfc69e6688f9ed7cc357aL99-R112) [[2]](diffhunk://#diff-cec9a6cf2d86f17c13659a5f547f9b0479b4f3a52fccfc69e6688f9ed7cc357aL296-R421)
* Errors during retention no longer cause the backup to fail entirely; instead, they are logged and included as warnings in notifications, improving robustness and observability.

**Notification and logging enhancements:**

* Notification messages sent after backup completion now include more granular retention results (deleted, already missing, failed) and any warnings, providing better feedback to users.
* All HTTP status code extraction is centralized in a new helper function for consistency.

**Testing improvements:**

* A new test module (`test_google_shared_drive.py`) has been added, providing comprehensive tests for the retention policy, including scenarios for successful deletion, handling of missing snapshots (404), non-404 failures, skipping recent snapshots, and ensuring backup success even when retention crashes.