### PR TITLE
Fix import for new associate functionality

### DIFF
--- a/gris/api/associate/importer.py
+++ b/gris/api/associate/importer.py
@@ -232,8 +232,13 @@ def _upsert_responsavel(payload: dict) -> tuple[str | None, str]:
 	return new_resp.name, "created"
 
 
-def _upsert_responsavel_vinculo(responsavel_name: str, associado_name: str) -> str:
-	"""Retorna action em {created, updated, skipped}."""
+def _upsert_responsavel_vinculo(responsavel_name: str, associado_name: str, cpf_raw: str = "") -> str:
+	"""Retorna action em {created, updated, skipped}.
+
+	Se já existir um vínculo entre o responsável e o Novo Associado correspondente
+	(criado na recepção), atualiza o vínculo existente adicionando o Associado.
+	"""
+	# 1. Buscar vínculo já ligado ao Associado
 	existing_link_name = frappe.db.get_value(
 		"Responsavel Vinculo",
 		{"responsavel": responsavel_name, "beneficiario_associado": associado_name},
@@ -246,6 +251,24 @@ def _upsert_responsavel_vinculo(responsavel_name: str, associado_name: str) -> s
 			return "updated"
 		return "skipped"
 
+	# 2. Buscar vínculo existente via Novo Associado (criado na recepção)
+	if cpf_raw:
+		cpf_clean = re.sub(r"\D", "", cpf_raw)
+		na_name = hashlib.md5(cpf_clean.encode("utf-8")).hexdigest()
+		na_link_name = frappe.db.get_value(
+			"Responsavel Vinculo",
+			{"responsavel": responsavel_name, "beneficiario_novo_associado": na_name},
+			"name",
+		)
+		if na_link_name:
+			frappe.db.set_value(
+				"Responsavel Vinculo",
+				na_link_name,
+				{"beneficiario_associado": associado_name, "é_guardiao_legal": 1},
+			)
+			return "updated"
+
+	# 3. Criar novo vínculo
 	new_link = frappe.new_doc("Responsavel Vinculo")
 	new_link.responsavel = responsavel_name
 	new_link.beneficiario_associado = associado_name
@@ -502,7 +525,7 @@ def parse_associates_report(path_pdf: str) -> dict:
 						results[f"responsavel_{responsavel_action}"] += 1
 
 						if responsavel_name:
-							vinculo_action = _upsert_responsavel_vinculo(responsavel_name, associado_name)
+							vinculo_action = _upsert_responsavel_vinculo(responsavel_name, associado_name, cpf)
 							results[f"vinculo_{vinculo_action}"] += 1
 						else:
 							results["vinculo_skipped"] += 1

--- a/gris/gris/doctype/novo_associado/novo_associado.py
+++ b/gris/gris/doctype/novo_associado/novo_associado.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2025, Grupo Escoteiro Professora Inah de Mello - 47/SP and contributors
 # For license information, please see license.txt
 
-# import frappe
 import hashlib
 import re
 
+import frappe
 from frappe.model.document import Document
 
 
@@ -13,3 +13,15 @@ class NovoAssociado(Document):
 		if self.cpf:
 			cpf_clean = re.sub(r"\D", "", self.cpf)
 			self.name = hashlib.md5(cpf_clean.encode("utf-8")).hexdigest()
+
+	def on_trash(self):
+		"""Limpa referências em Responsavel Vinculo ao excluir Novo Associado."""
+		vinculos = frappe.get_all(
+			"Responsavel Vinculo",
+			filters={"beneficiario_novo_associado": self.name},
+			pluck="name",
+		)
+		for vinculo_name in vinculos:
+			frappe.db.set_value(
+				"Responsavel Vinculo", vinculo_name, "beneficiario_novo_associado", None
+			)

--- a/gris/tests/test_responsavel_vinculo_import.py
+++ b/gris/tests/test_responsavel_vinculo_import.py
@@ -1,0 +1,236 @@
+"""Testes para o fluxo de vínculo responsável ↔ associado durante importação.
+
+Cenários cobertos:
+1. Importação com vínculo pré-existente via Novo Associado → atualiza vínculo
+2. Importação sem vínculo pré-existente → cria novo vínculo
+3. Re-importação (vínculo já com beneficiario_associado) → skip
+4. on_trash do Novo Associado limpa referência no vínculo
+5. processar_desistencia não é afetado pelo on_trash
+"""
+
+import hashlib
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from gris.api.associate.importer import _upsert_responsavel_vinculo
+
+# CPFs fictícios para testes
+CPF_JOVEM = "00000000001"
+CPF_RESP = "00000000002"
+CPF_JOVEM2 = "00000000003"
+
+
+def _md5(value: str) -> str:
+	return hashlib.md5(value.encode("utf-8")).hexdigest()
+
+
+def _create_responsavel(cpf: str) -> str:
+	if frappe.db.exists("Responsavel", _md5(cpf)):
+		return _md5(cpf)
+	doc = frappe.get_doc({"doctype": "Responsavel", "cpf": cpf, "nome_completo": f"Resp {cpf}"})
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _create_novo_associado(cpf: str) -> str:
+	if frappe.db.exists("Novo Associado", _md5(cpf)):
+		return _md5(cpf)
+	doc = frappe.get_doc({"doctype": "Novo Associado", "cpf": cpf, "nome_completo": f"Jovem {cpf}"})
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _create_associado(cpf: str) -> str:
+	name = _md5(cpf)
+	if frappe.db.exists("Associado", name):
+		return name
+	doc = frappe.get_doc({
+		"doctype": "Associado",
+		"cpf": cpf,
+		"nome_completo": f"Assoc {cpf}",
+		"data_de_nascimento": "2015-01-01",
+	})
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _create_vinculo(responsavel_name: str, novo_associado_name: str = None, associado_name: str = None) -> str:
+	doc = frappe.get_doc({
+		"doctype": "Responsavel Vinculo",
+		"responsavel": responsavel_name,
+		"beneficiario_novo_associado": novo_associado_name,
+		"beneficiario_associado": associado_name,
+		"é_guardiao_legal": 1,
+	})
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+class TestResponsavelVinculoImport(FrappeTestCase):
+	"""Testa o fluxo de upsert de vínculo durante importação de associados."""
+
+	def setUp(self):
+		# Limpar registros de teste antes de cada teste
+		self._cleanup()
+
+	def tearDown(self):
+		self._cleanup()
+
+	def _cleanup(self):
+		"""Remove registros de teste criados."""
+		for cpf in [CPF_JOVEM, CPF_RESP, CPF_JOVEM2]:
+			md5 = _md5(cpf)
+			# Vínculos
+			for v in frappe.get_all(
+				"Responsavel Vinculo",
+				or_filters={
+					"responsavel": md5,
+					"beneficiario_novo_associado": md5,
+					"beneficiario_associado": md5,
+				},
+				pluck="name",
+			):
+				frappe.delete_doc("Responsavel Vinculo", v, ignore_permissions=True, force=True)
+			# Associados
+			if frappe.db.exists("Associado", md5):
+				frappe.delete_doc("Associado", md5, ignore_permissions=True, force=True)
+			# Novo Associado
+			if frappe.db.exists("Novo Associado", md5):
+				frappe.delete_doc("Novo Associado", md5, ignore_permissions=True, force=True)
+			# Responsavel
+			if frappe.db.exists("Responsavel", md5):
+				frappe.delete_doc("Responsavel", md5, ignore_permissions=True, force=True)
+		frappe.db.commit()
+
+	def test_01_import_updates_existing_novo_associado_vinculo(self):
+		"""Cenário principal: vínculo existe via Novo Associado, importação deve atualizar."""
+		resp_name = _create_responsavel(CPF_RESP)
+		na_name = _create_novo_associado(CPF_JOVEM)
+		vinculo_name = _create_vinculo(resp_name, novo_associado_name=na_name)
+		frappe.db.commit()
+
+		# Simular criação do Associado (como faria a importação)
+		assoc_name = _create_associado(CPF_JOVEM)
+		frappe.db.commit()
+
+		# Chamar upsert passando cpf_raw (como faz o importer)
+		action = _upsert_responsavel_vinculo(resp_name, assoc_name, CPF_JOVEM)
+		frappe.db.commit()
+
+		self.assertEqual(action, "updated")
+
+		# Verificar que o vínculo foi atualizado (mesmo registro, não um novo)
+		vinculo = frappe.get_doc("Responsavel Vinculo", vinculo_name)
+		self.assertEqual(vinculo.beneficiario_associado, assoc_name)
+		self.assertEqual(vinculo.beneficiario_novo_associado, na_name)
+		self.assertEqual(int(vinculo.é_guardiao_legal), 1)
+
+		# Verificar que NÃO foi criado um segundo vínculo
+		count = frappe.db.count("Responsavel Vinculo", {"responsavel": resp_name})
+		self.assertEqual(count, 1)
+
+	def test_02_import_creates_vinculo_when_no_preexisting(self):
+		"""Sem vínculo pré-existente: cria novo normalmente."""
+		resp_name = _create_responsavel(CPF_RESP)
+		assoc_name = _create_associado(CPF_JOVEM)
+		frappe.db.commit()
+
+		action = _upsert_responsavel_vinculo(resp_name, assoc_name, CPF_JOVEM)
+		frappe.db.commit()
+
+		self.assertEqual(action, "created")
+
+		# Verificar que o vínculo foi criado
+		exists = frappe.db.get_value(
+			"Responsavel Vinculo",
+			{"responsavel": resp_name, "beneficiario_associado": assoc_name},
+			"name",
+		)
+		self.assertTrue(exists)
+
+	def test_03_reimport_skips_when_vinculo_already_has_associado(self):
+		"""Re-importação: vínculo já com beneficiario_associado → skip."""
+		resp_name = _create_responsavel(CPF_RESP)
+		assoc_name = _create_associado(CPF_JOVEM)
+		frappe.db.commit()
+
+		# Primeira importação
+		action1 = _upsert_responsavel_vinculo(resp_name, assoc_name, CPF_JOVEM)
+		frappe.db.commit()
+		self.assertEqual(action1, "created")
+
+		# Segunda importação (re-import)
+		action2 = _upsert_responsavel_vinculo(resp_name, assoc_name, CPF_JOVEM)
+		self.assertEqual(action2, "skipped")
+
+		# Apenas 1 registro
+		count = frappe.db.count(
+			"Responsavel Vinculo",
+			{"responsavel": resp_name, "beneficiario_associado": assoc_name},
+		)
+		self.assertEqual(count, 1)
+
+	def test_04_on_trash_clears_novo_associado_reference(self):
+		"""Ao excluir Novo Associado, o campo beneficiario_novo_associado fica null."""
+		resp_name = _create_responsavel(CPF_RESP)
+		na_name = _create_novo_associado(CPF_JOVEM)
+		assoc_name = _create_associado(CPF_JOVEM)
+		frappe.db.commit()
+
+		# Criar vínculo com ambos preenchidos (estado pós-importação)
+		vinculo_name = _create_vinculo(resp_name, novo_associado_name=na_name, associado_name=assoc_name)
+		frappe.db.commit()
+
+		# Excluir Novo Associado
+		frappe.delete_doc("Novo Associado", na_name, ignore_permissions=True)
+		frappe.db.commit()
+
+		# Verificar que o vínculo ainda existe mas sem referência ao Novo Associado
+		vinculo = frappe.get_doc("Responsavel Vinculo", vinculo_name)
+		self.assertIsNone(vinculo.beneficiario_novo_associado)
+		self.assertEqual(vinculo.beneficiario_associado, assoc_name)
+		self.assertEqual(vinculo.responsavel, resp_name)
+
+	def test_05_on_trash_only_cleans_not_deletes(self):
+		"""on_trash do Novo Associado NÃO deleta o vínculo (pode ter Associado)."""
+		resp_name = _create_responsavel(CPF_RESP)
+		na_name = _create_novo_associado(CPF_JOVEM)
+		vinculo_name = _create_vinculo(resp_name, novo_associado_name=na_name)
+		frappe.db.commit()
+
+		# Excluir Novo Associado
+		frappe.delete_doc("Novo Associado", na_name, ignore_permissions=True)
+		frappe.db.commit()
+
+		# Vínculo deve continuar existindo
+		self.assertTrue(frappe.db.exists("Responsavel Vinculo", vinculo_name))
+		vinculo = frappe.get_doc("Responsavel Vinculo", vinculo_name)
+		self.assertIsNone(vinculo.beneficiario_novo_associado)
+
+	def test_06_no_integrity_error_on_name_collision(self):
+		"""Garante que não ocorre IntegrityError quando nomes colidem (cenário do bug)."""
+		resp_name = _create_responsavel(CPF_RESP)
+		na_name = _create_novo_associado(CPF_JOVEM)
+
+		# Vínculo via recepção: name = resp_hash + "" + na_hash
+		vinculo_name = _create_vinculo(resp_name, novo_associado_name=na_name)
+		frappe.db.commit()
+
+		# Criar Associado com mesmo CPF (importação)
+		assoc_name = _create_associado(CPF_JOVEM)
+		frappe.db.commit()
+
+		# Sem o fix, isto daria IntegrityError (Duplicate entry)
+		# porque resp_hash + assoc_hash + "" == resp_hash + "" + na_hash
+		try:
+			action = _upsert_responsavel_vinculo(resp_name, assoc_name, CPF_JOVEM)
+			frappe.db.commit()
+		except Exception as e:
+			self.fail(f"IntegrityError inesperado: {e}")
+
+		self.assertEqual(action, "updated")
+
+		# Apenas 1 registro
+		count = frappe.db.count("Responsavel Vinculo", {"responsavel": resp_name})
+		self.assertEqual(count, 1)


### PR DESCRIPTION
This pull request introduces significant improvements to the process of linking ("vínculo") between responsible persons and associates, especially during import operations. The changes ensure that existing links created via "Novo Associado" are correctly updated when the associate is later imported, prevent duplicate links, and clean up references when "Novo Associado" records are deleted. Comprehensive tests are also added to cover these scenarios and prevent regressions.

Key changes include:

### Import and Link Management Improvements

* Enhanced the `_upsert_responsavel_vinculo` function to check for and update existing links that were created via "Novo Associado" when importing an associate, using the CPF as a reference. This prevents duplicate "Responsavel Vinculo" records and ensures data consistency. [[1]](diffhunk://#diff-3cd17b52be917a359be68b0e4f0da37d5a833fa796986c71ae3a18244ab00e4fL235-R241) [[2]](diffhunk://#diff-3cd17b52be917a359be68b0e4f0da37d5a833fa796986c71ae3a18244ab00e4fR254-R271) [[3]](diffhunk://#diff-3cd17b52be917a359be68b0e4f0da37d5a833fa796986c71ae3a18244ab00e4fL505-R528)
* Modified the import process to always pass the CPF to `_upsert_responsavel_vinculo`, enabling the new logic for updating existing links.

### Data Integrity and Cleanup

* Implemented the `on_trash` method in `Novo Associado` to clear references in "Responsavel Vinculo" records when a "Novo Associado" is deleted, avoiding orphaned references and maintaining referential integrity.

### Testing

* Added a comprehensive test suite (`test_responsavel_vinculo_import.py`) covering scenarios such as updating existing links, creating new links, skipping re-imports, cleaning up on deletion, and ensuring no integrity errors occur due to name collisions. This ensures the robustness of the new logic and prevents regressions.

### Code Quality

* Cleaned up imports in `novo_associado.py` for consistency and clarity.