### PR TITLE
Add beneficiary button and validate CPF for associates and guardians

### DIFF
--- a/gris/www/responsavel/beneficiarios.css
+++ b/gris/www/responsavel/beneficiarios.css
@@ -199,3 +199,48 @@
 		justify-content: center;
 	}
 }
+
+/* Section header actions */
+.section-header-wrap {
+	flex-wrap: wrap;
+	gap: 0.75rem;
+}
+
+.section-header-actions {
+	display: flex;
+	gap: 0.75rem;
+	flex-shrink: 0;
+}
+
+@media (max-width: 768px) {
+	.section-header-wrap {
+		flex-direction: column;
+		align-items: stretch !important;
+	}
+
+	.section-header-actions {
+		flex-direction: column;
+		width: 100%;
+	}
+
+	.section-header-actions .btn-modern {
+		width: 100%;
+		justify-content: center;
+	}
+}
+
+/* Adicionar Beneficiário form spacing */
+#form-adicionar-beneficiario .form-group-modern {
+	margin-bottom: 1rem;
+}
+
+#form-adicionar-beneficiario .is-invalid {
+	border-color: var(--color-danger, #dc3545);
+}
+
+#form-adicionar-beneficiario .is-invalid + .invalid-feedback {
+	display: block;
+	color: var(--color-danger, #dc3545);
+	font-size: 0.8rem;
+	margin-top: 0.25rem;
+}

--- a/gris/www/responsavel/beneficiarios.html
+++ b/gris/www/responsavel/beneficiarios.html
@@ -77,13 +77,19 @@
 
 	<!-- Section 2: Beneficiários em processo de integração -->
 	<section>
-		<div class="d-flex justify-content-between align-items-center mb-3">
+		<div class="d-flex justify-content-between align-items-center mb-3 section-header-wrap">
 			<h2 class="section-title mb-0">Beneficiários em processo de integração</h2>
-			{% if show_schedule_button %}
-				<button class="btn-modern btn-modern--primary" id="btn-agendar-visita">
-					Agendar Visita
+			<div class="section-header-actions">
+				<button class="btn-modern btn-modern--primary" id="btn-adicionar-beneficiario">
+					<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right: 4px;"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path><circle cx="8.5" cy="7" r="4"></circle><line x1="20" y1="8" x2="20" y2="14"></line><line x1="23" y1="11" x2="17" y2="11"></line></svg>
+					Adicionar Beneficiário
 				</button>
-			{% endif %}
+				{% if show_schedule_button %}
+					<button class="btn-modern btn-modern--primary" id="btn-agendar-visita">
+						Agendar Visita
+					</button>
+				{% endif %}
+			</div>
 		</div>
 		
 		{% if beneficiarios_integracao %}
@@ -157,7 +163,45 @@
 		</div>
 	</div>
 
+	<!-- Modal Adicionar Beneficiário -->
+	<div class="modal-backdrop" id="modalAdicionarBackdrop" style="display: none;"></div>
+	<div class="modal-modern" id="modalAdicionar" tabindex="-1" style="display: none;">
+		<div class="modal-dialog">
+			<div class="modal-modern__content">
+				<div class="modal-modern__header">
+					<h5 class="modal-modern__title">Adicionar Beneficiário</h5>
+				</div>
+				<div class="modal-modern__body">
+					<p class="text-muted mb-3">Informe os dados do jovem que deseja cadastrar.</p>
+					<p class="text-muted small mb-3"><span class="text-danger">*</span> Campos obrigatórios</p>
+					<form id="form-adicionar-beneficiario" novalidate>
+						<div class="form-group-modern">
+							<label for="add_nome_jovem" class="form-label-modern form-label-modern--required">Nome Completo do Jovem</label>
+							<input type="text" class="form-input-modern" id="add_nome_jovem" required>
+							<div class="invalid-feedback">Por favor, insira um nome válido (somente letras e espaços).</div>
+						</div>
+						<div class="form-group-modern">
+							<label for="add_cpf_jovem" class="form-label-modern form-label-modern--required">CPF do Jovem</label>
+							<input type="text" class="form-input-modern" id="add_cpf_jovem" required maxlength="14" placeholder="000.000.000-00">
+							<div class="invalid-feedback">CPF inválido.</div>
+						</div>
+						<div class="form-group-modern">
+							<label for="add_data_nascimento_jovem" class="form-label-modern form-label-modern--required">Data de Nascimento</label>
+							<input type="date" class="form-input-modern" id="add_data_nascimento_jovem" required>
+							<div class="invalid-feedback">Por favor, insira uma data válida anterior a hoje.</div>
+						</div>
+					</form>
+				</div>
+				<div class="modal-modern__footer">
+					<button type="button" class="btn-modern btn-modern--ghost" data-dismiss-modal>Cancelar</button>
+					<button type="button" class="btn-modern btn-modern--primary" id="btn-confirmar-adicionar">Adicionar</button>
+				</div>
+			</div>
+		</div>
+	</div>
+
 </div>
+<div id="responsavel-data" data-cpf="{{ responsavel_cpf }}" style="display:none;"></div>
 {% endblock %}
 
 {% block script %}

--- a/gris/www/responsavel/beneficiarios.js
+++ b/gris/www/responsavel/beneficiarios.js
@@ -8,6 +8,150 @@ frappe.ready(function() {
 	const btnCancelar = document.getElementById('btn-cancelar-visita');
 	let selectedDate = null;
 	let isReschedule = false;
+
+	// --- Modal Adicionar Beneficiário ---
+	const btnAdicionar = document.getElementById('btn-adicionar-beneficiario');
+	const modalAdicionar = document.getElementById('modalAdicionar');
+	const backdropAdicionar = document.getElementById('modalAdicionarBackdrop');
+	const btnConfirmarAdicionar = document.getElementById('btn-confirmar-adicionar');
+	const formAdicionar = document.getElementById('form-adicionar-beneficiario');
+	const inputNome = document.getElementById('add_nome_jovem');
+	const inputCpf = document.getElementById('add_cpf_jovem');
+	const inputDataNasc = document.getElementById('add_data_nascimento_jovem');
+	const responsavelCpf = (document.getElementById('responsavel-data')?.dataset.cpf || '').replace(/\D/g, '');
+
+	if (btnAdicionar) {
+		btnAdicionar.addEventListener('click', function() {
+			openModalAdicionar();
+		});
+	}
+
+	if (btnConfirmarAdicionar) {
+		btnConfirmarAdicionar.addEventListener('click', function() {
+			submitAdicionarBeneficiario();
+		});
+	}
+
+	// Máscara de CPF para o campo do modal
+	if (inputCpf) {
+		inputCpf.addEventListener('input', function() {
+			let value = this.value.replace(/\D/g, '');
+			if (value.length > 11) value = value.slice(0, 11);
+			if (value.length > 9) {
+				value = value.replace(/^(\d{3})(\d{3})(\d{3})(\d{1,2}).*/, '$1.$2.$3-$4');
+			} else if (value.length > 6) {
+				value = value.replace(/^(\d{3})(\d{3})(\d{1,3}).*/, '$1.$2.$3');
+			} else if (value.length > 3) {
+				value = value.replace(/^(\d{3})(\d{1,3}).*/, '$1.$2');
+			}
+			this.value = value;
+		});
+	}
+
+	function openModalAdicionar() {
+		if (formAdicionar) formAdicionar.reset();
+		clearValidation();
+		if (modalAdicionar && backdropAdicionar) {
+			modalAdicionar.style.display = 'block';
+			backdropAdicionar.style.display = 'block';
+			setTimeout(() => {
+				modalAdicionar.classList.add('show');
+				backdropAdicionar.classList.add('show');
+			}, 10);
+		}
+	}
+
+	function closeModalAdicionar() {
+		if (modalAdicionar && backdropAdicionar) {
+			modalAdicionar.classList.remove('show');
+			backdropAdicionar.classList.remove('show');
+			setTimeout(() => {
+				modalAdicionar.style.display = 'none';
+				backdropAdicionar.style.display = 'none';
+			}, 300);
+		}
+	}
+
+	function clearValidation() {
+		if (formAdicionar) {
+			formAdicionar.querySelectorAll('.is-invalid').forEach(el => el.classList.remove('is-invalid'));
+		}
+	}
+
+	function validateCPF(cpf) {
+		cpf = cpf.replace(/\D/g, '');
+		if (cpf.length !== 11) return false;
+		if (/^(\d)\1{10}$/.test(cpf)) return false;
+		let sum = 0;
+		for (let i = 0; i < 9; i++) sum += parseInt(cpf.charAt(i)) * (10 - i);
+		let remainder = 11 - (sum % 11);
+		if (remainder === 10 || remainder === 11) remainder = 0;
+		if (remainder !== parseInt(cpf.charAt(9))) return false;
+		sum = 0;
+		for (let i = 0; i < 10; i++) sum += parseInt(cpf.charAt(i)) * (11 - i);
+		remainder = 11 - (sum % 11);
+		if (remainder === 10 || remainder === 11) remainder = 0;
+		return remainder === parseInt(cpf.charAt(10));
+	}
+
+	function validateAdicionarForm() {
+		clearValidation();
+		let valid = true;
+
+		const nome = (inputNome.value || '').trim();
+		if (!nome || !/^[A-Za-zÀ-ÿ\s]+$/.test(nome)) {
+			inputNome.classList.add('is-invalid');
+			valid = false;
+		}
+
+		const cpfValue = (inputCpf.value || '').trim();
+		if (!validateCPF(cpfValue)) {
+			inputCpf.classList.add('is-invalid');
+			valid = false;
+		} else {
+			const cpfLimpo = cpfValue.replace(/\D/g, '');
+			if (responsavelCpf && cpfLimpo === responsavelCpf) {
+				inputCpf.classList.add('is-invalid');
+				inputCpf.nextElementSibling.textContent = 'O CPF do jovem não pode ser o mesmo do responsável.';
+				valid = false;
+			}
+		}
+
+		const dataNasc = inputDataNasc.value;
+		if (!dataNasc || new Date(dataNasc) >= new Date(new Date().toISOString().split('T')[0])) {
+			inputDataNasc.classList.add('is-invalid');
+			valid = false;
+		}
+
+		return valid;
+	}
+
+	function submitAdicionarBeneficiario() {
+		if (!validateAdicionarForm()) return;
+
+		frappe.call({
+			method: 'gris.www.responsavel.beneficiarios.adicionar_beneficiario',
+			args: {
+				nome_jovem: inputNome.value.trim(),
+				cpf_jovem: inputCpf.value.trim(),
+				data_nascimento_jovem: inputDataNasc.value
+			},
+			freeze: true,
+			freeze_message: 'Adicionando beneficiário...',
+			callback: function(r) {
+				if (r.message && r.message.ok) {
+					closeModalAdicionar();
+					frappe.msgprint(r.message.message || 'Beneficiário adicionado com sucesso!');
+					setTimeout(() => { window.location.reload(); }, 1500);
+				}
+			}
+		});
+	}
+
+	// Close handlers for adicionar modal
+	if (backdropAdicionar) {
+		backdropAdicionar.addEventListener('click', closeModalAdicionar);
+	}
 	
 	if (btnAgendar) {
 		btnAgendar.addEventListener('click', function() {
@@ -62,7 +206,10 @@ frappe.ready(function() {
 
 	// Close modal handlers
 	document.querySelectorAll('[data-dismiss-modal]').forEach(btn => {
-		btn.addEventListener('click', closeModal);
+		btn.addEventListener('click', function() {
+			closeModal();
+			closeModalAdicionar();
+		});
 	});
 	
 	if (backdrop) {

--- a/gris/www/responsavel/beneficiarios.py
+++ b/gris/www/responsavel/beneficiarios.py
@@ -1,5 +1,7 @@
+import re
+
 import frappe
-from frappe.utils import add_days, cint, getdate, today
+from frappe.utils import add_days, cint, getdate, now, today
 
 from gris.api.portal_access import enrich_context
 
@@ -244,10 +246,14 @@ def get_context(context):
 					visit_info.data_da_visita, {"fieldtype": "Date"}
 				)
 
+	# CPF do responsável para validação client-side (não exibido, apenas para comparação)
+	responsavel_cpf = frappe.db.get_value("Responsavel", responsavel_name, "cpf") or ""
+
 	context.visit_info = visit_info
 	context.beneficiarios_registrados = beneficiarios_registrados
 	context.beneficiarios_integracao = beneficiarios_integracao
 	context.show_schedule_button = show_schedule_button and not visit_info
+	context.responsavel_cpf = responsavel_cpf
 
 	context.sidebar_title = "Painel do Responsável"
 	context.active_link = "/responsavel/beneficiarios"
@@ -432,3 +438,112 @@ def _status_badge_class(status):
 	if status == "vencido":
 		return "g-badge--warning"
 	return "g-badge--secondary"
+
+
+@frappe.whitelist()
+def adicionar_beneficiario(nome_jovem, cpf_jovem, data_nascimento_jovem):
+	"""Adiciona um novo beneficiário (jovem) vinculado ao responsável logado.
+
+	Cria Novo Associado com status 'Conversa Inicial', registra auditoria
+	em Resposta Manifestacao de Interesse e cria o vínculo.
+	"""
+	user = frappe.session.user
+	if user == "Guest":
+		frappe.throw("Acesso negado.", frappe.PermissionError)
+
+	if "Responsavel" not in frappe.get_roles(user):
+		frappe.throw("Você não tem permissão para esta operação.", frappe.PermissionError)
+
+	responsavel_name = _get_responsavel_name(user)
+	if not responsavel_name:
+		frappe.throw("Responsável não encontrado para o usuário logado.")
+
+	# Validar campos obrigatórios
+	nome_jovem = (nome_jovem or "").strip()
+	cpf_jovem = (cpf_jovem or "").strip()
+	data_nascimento_jovem = (data_nascimento_jovem or "").strip()
+
+	if not nome_jovem or not cpf_jovem or not data_nascimento_jovem:
+		frappe.throw("Todos os campos são obrigatórios: nome, CPF e data de nascimento.")
+
+	# Validar formato do nome (somente letras, espaços e acentos)
+	if not re.match(r"^[A-Za-zÀ-ÿ\s]+$", nome_jovem):
+		frappe.throw("Nome do jovem deve conter apenas letras e espaços.")
+
+	# Normalizar CPF (remover formatação)
+	cpf_limpo = re.sub(r"\D", "", cpf_jovem)
+	if len(cpf_limpo) != 11:
+		frappe.throw("CPF do jovem deve conter 11 dígitos.")
+
+	# Validar data de nascimento (deve ser anterior a hoje)
+	try:
+		data_nasc = getdate(data_nascimento_jovem)
+	except Exception:
+		frappe.throw("Data de nascimento inválida.")
+
+	if data_nasc >= getdate(today()):
+		frappe.throw("Data de nascimento deve ser anterior a hoje.")
+
+	# Buscar dados do responsável
+	responsavel_doc = frappe.get_doc("Responsavel", responsavel_name)
+
+	# CPF do jovem não pode ser igual ao do responsável
+	cpf_responsavel_limpo = re.sub(r"\D", "", responsavel_doc.cpf or "")
+	if cpf_limpo == cpf_responsavel_limpo:
+		frappe.throw("O CPF do jovem não pode ser o mesmo do responsável.")
+
+	# Verificar se já existe Novo Associado com o mesmo CPF
+	existing_novo_associado = frappe.db.exists("Novo Associado", {"cpf": cpf_jovem})
+	if existing_novo_associado:
+		frappe.throw(
+			"Já existe um jovem cadastrado com este CPF. Verifique os dados ou entre em contato com o grupo."
+		)
+
+	savepoint_name = f"add_beneficiario_{frappe.generate_hash(length=8)}"
+	frappe.db.savepoint(savepoint_name)
+
+	try:
+		# 1. Registrar auditoria em Resposta Manifestacao de Interesse
+		frappe.get_doc(
+			{
+				"doctype": "Resposta Manifestacao de Interesse",
+				"nome_do_responsavel": responsavel_doc.nome_completo,
+				"email_do_responsavel": responsavel_doc.email,
+				"celular_do_responsavel": responsavel_doc.celular,
+				"cpf_do_responsavel": responsavel_doc.cpf,
+				"nome_do_jovem": nome_jovem,
+				"data_de_nascimento_do_jovem": data_nascimento_jovem,
+				"cpf_do_jovem": cpf_jovem,
+				"data_e_horario_de_resposta": now(),
+				"dados_confirmados": 1,
+				"aceite_lgpd": 1,
+			}
+		).insert(ignore_permissions=True)
+
+		# 2. Criar Novo Associado com status "Conversa Inicial"
+		novo_associado_doc = frappe.get_doc(
+			{
+				"doctype": "Novo Associado",
+				"nome_completo": nome_jovem,
+				"data_de_nascimento": data_nascimento_jovem,
+				"cpf": cpf_jovem,
+				"status": "Conversa Inicial",
+			}
+		)
+		novo_associado_doc.insert(ignore_permissions=True)
+
+		# 3. Criar Responsavel Vinculo
+		frappe.get_doc(
+			{
+				"doctype": "Responsavel Vinculo",
+				"responsavel": responsavel_name,
+				"beneficiario_novo_associado": novo_associado_doc.name,
+			}
+		).insert(ignore_permissions=True)
+
+		return {"ok": True, "message": "Beneficiário adicionado com sucesso!"}
+
+	except Exception:
+		frappe.db.rollback(save_point=savepoint_name)
+		frappe.log_error("Erro ao adicionar beneficiário")
+		frappe.throw("Ocorreu um erro ao adicionar o beneficiário. Tente novamente.")

--- a/gris/www/responsavel/registro.js
+++ b/gris/www/responsavel/registro.js
@@ -371,6 +371,51 @@ frappe.ready(function() {
             }
         });
 
+        // Validate Duplicate CPFs
+        if (isValid) {
+            const cpfEntries = [];
+            const mainCpfRaw = $('#cpf').val();
+            if (mainCpfRaw) {
+                cpfEntries.push({ digits: mainCpfRaw.replace(/\D/g, ''), label: 'Novo Associado', field: $('#cpf') });
+            }
+            $('.responsavel-wrapper:visible .responsavel-card').each(function() {
+                const card = $(this);
+                const respName = card.find('.responsavel-card__title').text() || 'Responsável';
+                const respCpfField = card.find('input[data-fieldname="cpf"]');
+                const val = respCpfField.val();
+                if (val) {
+                    cpfEntries.push({ digits: val.replace(/\D/g, ''), label: respName, field: respCpfField });
+                }
+            });
+
+            const seen = {};
+            const duplicates = [];
+            cpfEntries.forEach(entry => {
+                if (!entry.digits) return;
+                if (seen[entry.digits]) {
+                    duplicates.push(entry);
+                    if (!seen[entry.digits].flagged) {
+                        duplicates.push(seen[entry.digits]);
+                        seen[entry.digits].flagged = true;
+                    }
+                } else {
+                    seen[entry.digits] = entry;
+                }
+            });
+
+            if (duplicates.length) {
+                duplicates.forEach(d => d.field.addClass('is-invalid'));
+                const names = [...new Set(duplicates.map(d => d.label))].join(', ');
+                frappe.msgprint({
+                    title: 'CPF Duplicado',
+                    indicator: 'red',
+                    message: `Os CPFs devem ser distintos. CPFs repetidos encontrados em: ${names}.`
+                });
+                isValid = false;
+                if (!firstInvalidField) firstInvalidField = duplicates[0].field;
+            }
+        }
+
         if (!isValid) return;
 
         let $btn = $(this).find('button[type="submit"]');

--- a/gris/www/responsavel/registro.py
+++ b/gris/www/responsavel/registro.py
@@ -219,6 +219,34 @@ def update_novo_associado(novo_associado_name, data, responsaveis_data=None):
 		if isinstance(responsaveis_data, str):
 			responsaveis_data = json.loads(responsaveis_data)
 
+		# Validate duplicate CPFs across associado and responsáveis
+		all_cpfs = []
+		associado_cpf = re.sub(r"\D", "", data.get("cpf") or "")
+		if associado_cpf:
+			all_cpfs.append((associado_cpf, "Novo Associado"))
+
+		for resp_item in responsaveis_data:
+			if not resp_item.get("nome_completo") and not resp_item.get("cpf"):
+				continue
+			resp_cpf = re.sub(r"\D", "", resp_item.get("cpf") or "")
+			if resp_cpf:
+				resp_label = resp_item.get("nome_completo") or "Responsável"
+				all_cpfs.append((resp_cpf, resp_label))
+
+		seen_cpfs = {}
+		duplicates = []
+		for cpf_digits, label in all_cpfs:
+			if cpf_digits in seen_cpfs:
+				duplicates.append(label)
+				if seen_cpfs[cpf_digits] not in duplicates:
+					duplicates.append(seen_cpfs[cpf_digits])
+			else:
+				seen_cpfs[cpf_digits] = label
+
+		if duplicates:
+			nomes = ", ".join(dict.fromkeys(duplicates))
+			frappe.throw(f"Os CPFs devem ser distintos. CPFs repetidos encontrados em: {nomes}.")
+
 		for resp_item in responsaveis_data:
 			resp_id = resp_item.get("name")
 


### PR DESCRIPTION
This pull request introduces the "Adicionar Beneficiário" (Add Beneficiary) feature for responsible users, including a modal form with client- and server-side validations, as well as improvements to CPF (Brazilian taxpayer ID) duplication checks across the registration flow. The main changes are grouped into three themes: new beneficiary modal and UI, backend logic for beneficiary creation, and CPF validation enhancements.

**New UI and Modal for Adding Beneficiaries:**

* Added a new "Adicionar Beneficiário" button and modal dialog to the beneficiaries page (`beneficiarios.html`), allowing responsible users to register a new beneficiary via a form. The modal includes client-side validation for name, CPF, and date of birth, with user-friendly error feedback. [[1]](diffhunk://#diff-ce8268e4ba2c64a1f70d3ce1da16d6d83ef55e68f253e3f8a1495a4b6fae0006L80-R93) [[2]](diffhunk://#diff-ce8268e4ba2c64a1f70d3ce1da16d6d83ef55e68f253e3f8a1495a4b6fae0006R166-R204) [[3]](diffhunk://#diff-ddd59c33402613911ff341cdfa6a4097cf5d4b44c5e6057bb0418ac4675abefcR202-R246) [[4]](diffhunk://#diff-cf9c85d9eb6981974f0738b9fb45f31752e8dde0907ffdbffc6dbcd3ba414e50R12-R155) [[5]](diffhunk://#diff-cf9c85d9eb6981974f0738b9fb45f31752e8dde0907ffdbffc6dbcd3ba414e50L65-R212)

**Backend Logic for Beneficiary Creation:**

* Implemented the `adicionar_beneficiario` server-side method in `beneficiarios.py`, which performs permission checks, validates input fields, ensures the CPF is unique and not the same as the responsible user, and creates the necessary records (`Novo Associado`, `Resposta Manifestacao de Interesse`, and `Responsavel Vinculo`). [[1]](diffhunk://#diff-a77c80266472e8d35821d5435a1a66047fc89acea91f0332cfb52b1073f9f20cR1-R4) [[2]](diffhunk://#diff-a77c80266472e8d35821d5435a1a66047fc89acea91f0332cfb52b1073f9f20cR441-R549)
* Exposes the responsible user's CPF to the frontend (hidden in the DOM) for client-side CPF comparison.

**CPF Validation and Duplication Checks:**

* Enhanced client-side CPF validation in the modal, including format enforcement and duplicate CPF checks against the responsible user.
* Improved CPF duplication detection in the registration flow, both on the client (`registro.js`) and server (`registro.py`), preventing repeated CPFs among the new associate and responsible parties. [[1]](diffhunk://#diff-18de16924b16b4f627e1f7842a01c0b0e968ad8c95428cdf837769ddbd834650R374-R418) [[2]](diffhunk://#diff-01d2b5ec222b24c844a44e4cf94a0380525f3f2943f27242d4cc5ae50b851547R222-R249)

These changes ensure a more robust and user-friendly process for adding beneficiaries, with comprehensive validation to maintain data integrity.