### PR TITLE
send message to reception group

### DIFF
--- a/gris/api/recepcao_notificacoes.py
+++ b/gris/api/recepcao_notificacoes.py
@@ -11,9 +11,9 @@ Responsabilidades:
 from __future__ import annotations
 
 import frappe
-from frappe.utils import add_days, getdate, today
+from frappe.utils import add_days, get_url, getdate, today
 
-from gris.utils.whatsapp import enviar_mensagem_formatada, enviar_texto
+from gris.utils.whatsapp import enviar_mensagem_formatada, enviar_para_grupo, enviar_texto
 
 
 def _buscar_telefone_responsavel(novo_associado_name: str) -> str | None:
@@ -73,6 +73,76 @@ def _buscar_endereco_grupo() -> str:
 	if uel.bairro:
 		partes.append(uel.bairro)
 	return ", ".join(partes) if partes else "a confirmar"
+
+
+def _calcular_idade_em_anos(data_nascimento: str | None) -> int | None:
+	"""Calcula a idade completa em anos a partir da data de nascimento."""
+	if not data_nascimento:
+		return None
+
+	try:
+		nascimento = getdate(data_nascimento)
+		hoje = getdate(today())
+		idade = hoje.year - nascimento.year - ((hoje.month, hoje.day) < (nascimento.month, nascimento.day))
+		return max(idade, 0)
+	except Exception:
+		return None
+
+
+def _montar_mensagem_nova_manifestacao(
+	*,
+	nome_jovem: str,
+	nome_responsavel: str,
+	idade_anos: int | None,
+) -> str:
+	idade_texto = f"{idade_anos} anos" if idade_anos is not None else "não informada"
+	link_visao_geral = get_url("/recepcao/visao_geral")
+	return (
+		"@todos\n\n"
+		"🎉 Nova manifestação de interesse recebida! 🎉\n\n"
+		f"*Jovem*: {nome_jovem}\n"
+		f"*Responsável*: {nome_responsavel}\n"
+		f"*Idade do jovem*: {idade_texto}.\n\n"
+		f"Acompanhe na Visão Geral: {link_visao_geral}"
+	)
+
+
+def notificar_nova_manifestacao_no_grupo_recepcao(
+	*,
+	nome_jovem: str,
+	nome_responsavel: str,
+	data_nascimento_jovem: str | None,
+	contexto: str,
+) -> None:
+	"""Envia aviso para o grupo WhatsApp da recepção sobre novo associado adicionado.
+
+	O grupo destinatário é definido em Configurações de Recepção > Grupo de recepção (WhatsApp).
+	Falha silenciosa com log para não interromper os fluxos de cadastro.
+	"""
+	logger = frappe.logger("recepcao_notificacoes", allow_site=True)
+
+	grupo_jid = (
+		frappe.db.get_single_value("Configuracoes de Recepcao", "grupo_recepcao_whatsapp") or ""
+	).strip()
+	if not grupo_jid:
+		logger.warning(
+			f"Notificação de nova manifestação não enviada: grupo de recepção não configurado ({contexto})."
+		)
+		return
+
+	mensagem = _montar_mensagem_nova_manifestacao(
+		nome_jovem=(nome_jovem or "").strip() or "Não informado",
+		nome_responsavel=(nome_responsavel or "").strip() or "Não informado",
+		idade_anos=_calcular_idade_em_anos(data_nascimento_jovem),
+	)
+
+	try:
+		enviar_para_grupo(grupo_jid, mensagem, mencionar_todos=True)
+	except Exception:
+		frappe.log_error(
+			frappe.get_traceback(),
+			f"Notificação nova manifestação (grupo recepção): {contexto}",
+		)
 
 
 def notificar_visita_agendada(novo_associado_name: str, data_visita: str) -> None:

--- a/gris/gris/doctype/configuracoes_de_recepcao/configuracoes_de_recepcao.js
+++ b/gris/gris/doctype/configuracoes_de_recepcao/configuracoes_de_recepcao.js
@@ -1,8 +1,59 @@
 // Copyright (c) 2026, Grupo Escoteiro Professora Inah de Mello - 47/SP and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Configuracoes de Recepcao", {
-// 	refresh(frm) {
+frappe.ui.form.on("Configuracoes de Recepcao", {
+	async refresh(frm) {
+		await carregar_opcoes_grupo_recepcao(frm);
+	},
+});
 
-// 	},
-// });
+async function carregar_opcoes_grupo_recepcao(frm) {
+	const fieldname = "grupo_recepcao_whatsapp";
+	const field = frm.fields_dict[fieldname];
+
+	if (!field) {
+		return;
+	}
+
+	try {
+		const response = await frappe.call({
+			method: "gris.utils.whatsapp.listar_grupos_whatsapp_para_select",
+		});
+
+		const grupos = Array.isArray(response.message) ? response.message : [];
+		const options = [{ label: "", value: "" }];
+		const optionValues = new Set();
+
+		grupos.forEach((grupo) => {
+			const value = (grupo.value || "").trim();
+			if (!value || optionValues.has(value)) {
+				return;
+			}
+
+			optionValues.add(value);
+			options.push({
+				label: (grupo.label || value).trim(),
+				value,
+			});
+		});
+
+		const valorAtual = (frm.doc[fieldname] || "").trim();
+		if (valorAtual && !optionValues.has(valorAtual)) {
+			options.push({
+				label: `${valorAtual} (selecionado anteriormente)`,
+				value: valorAtual,
+			});
+		}
+
+		field.df.options = options;
+		field.df.description =
+			"Selecione o grupo da recepção para envio de mensagens WhatsApp aos responsáveis.";
+		frm.refresh_field(fieldname);
+	} catch (error) {
+		console.warn("Não foi possível carregar os grupos do WhatsApp.", error);
+		field.df.options = [{ label: "", value: "" }];
+		field.df.description =
+			"Não foi possível carregar os grupos da instância WhatsApp. Verifique as configurações.";
+		frm.refresh_field(fieldname);
+	}
+}

--- a/gris/gris/doctype/configuracoes_de_recepcao/configuracoes_de_recepcao.json
+++ b/gris/gris/doctype/configuracoes_de_recepcao/configuracoes_de_recepcao.json
@@ -21,7 +21,9 @@
   "valores_de_registro_section",
   "valor_registro_provisorio",
   "column_break_qwxy",
-  "valor_registro_definitivo"
+  "valor_registro_definitivo",
+  "whatsapp_recepcao_section",
+  "grupo_recepcao_whatsapp"
  ],
  "fields": [
   {
@@ -117,6 +119,17 @@
    "fieldname": "valor_registro_definitivo",
    "fieldtype": "Currency",
    "label": "Registro Definitivo"
+  },
+  {
+   "fieldname": "whatsapp_recepcao_section",
+   "fieldtype": "Section Break",
+   "label": "WhatsApp da Recepção"
+  },
+  {
+   "description": "Grupo da recepção para envio de mensagens aos responsáveis pela recepção.",
+   "fieldname": "grupo_recepcao_whatsapp",
+   "fieldtype": "Select",
+   "label": "Grupo de recepção (WhatsApp)"
   }
  ],
  "grid_page_length": 50,

--- a/gris/gris/doctype/configuracoes_whatsapp/test_configuracoes_whatsapp.py
+++ b/gris/gris/doctype/configuracoes_whatsapp/test_configuracoes_whatsapp.py
@@ -1,9 +1,120 @@
 # Copyright (c) 2026, Grupo Escoteiro Professora Inah de Mello - 47/SP and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests.utils import FrappeTestCase
+
+from gris.utils import whatsapp as whatsapp_utils
 
 
 class TestConfiguracoesWhatsApp(FrappeTestCase):
-	pass
+	def test_enviar_para_grupo_com_mencao_de_todos_no_payload(self):
+		original_get_config = whatsapp_utils._get_config
+		original_post = whatsapp_utils._post
+		original_registrar_sucesso = whatsapp_utils._registrar_sucesso
+		original_logger = whatsapp_utils._logger
+
+		capturado = {}
+
+		class _DummyLogger:
+			def info(self, *args, **kwargs):
+				return None
+
+		try:
+			whatsapp_utils._get_config = lambda: {
+				"url_api": "https://evolution.example",
+				"api_key": "secret",
+				"nome_instancia": "instancia-1",
+			}
+
+			def _fake_post(endpoint, payload, config=None):
+				capturado["endpoint"] = endpoint
+				capturado["payload"] = payload
+				return {"status": "PENDING"}
+
+			whatsapp_utils._post = _fake_post
+			whatsapp_utils._registrar_sucesso = lambda: None
+			whatsapp_utils._logger = lambda: _DummyLogger()
+
+			resposta = whatsapp_utils.enviar_para_grupo(
+				"120363408543428156@g.us",
+				"@todos Mensagem de teste",
+				mencionar_todos=True,
+				enqueue=False,
+			)
+
+			self.assertEqual(resposta, {"status": "PENDING"})
+			self.assertEqual(capturado["endpoint"], "/message/sendText/instancia-1")
+			self.assertEqual(capturado["payload"]["number"], "120363408543428156@g.us")
+			self.assertEqual(capturado["payload"]["text"], "@todos Mensagem de teste")
+			self.assertTrue(capturado["payload"]["mentionsEveryOne"])
+		finally:
+			whatsapp_utils._get_config = original_get_config
+			whatsapp_utils._post = original_post
+			whatsapp_utils._registrar_sucesso = original_registrar_sucesso
+			whatsapp_utils._logger = original_logger
+
+	def test_listar_grupos_whatsapp_ordena_e_filtra_retorno(self):
+		original_get = whatsapp_utils._get
+		original_get_config = whatsapp_utils._get_config
+
+		try:
+			whatsapp_utils._get_config = lambda: {
+				"url_api": "https://evolution.example",
+				"api_key": "secret",
+				"nome_instancia": "instancia-1",
+			}
+			whatsapp_utils._get = lambda endpoint, params=None, config=None: [
+				{"id": "120363423777366208@g.us", "subject": "Contatos Santer"},
+				{"id": "120363408543428156@g.us", "subject": "Recepção"},
+				{"id": "", "subject": "Sem id"},
+			]
+
+			grupos = whatsapp_utils.listar_grupos_whatsapp()
+
+			self.assertEqual(
+				grupos,
+				[
+					{"id": "120363423777366208@g.us", "subject": "Contatos Santer"},
+					{"id": "120363408543428156@g.us", "subject": "Recepção"},
+				],
+			)
+		finally:
+			whatsapp_utils._get = original_get
+			whatsapp_utils._get_config = original_get_config
+
+	def test_listar_grupos_whatsapp_para_select_retorna_label_e_valor(self):
+		original_has_permission = whatsapp_utils.frappe.has_permission
+		original_listar_grupos_whatsapp = whatsapp_utils.listar_grupos_whatsapp
+
+		try:
+			whatsapp_utils.frappe.has_permission = lambda *args, **kwargs: True
+			whatsapp_utils.listar_grupos_whatsapp = lambda get_participants=False: [
+				{"id": "120363408543428156@g.us", "subject": "Recepção"}
+			]
+
+			opcoes = whatsapp_utils.listar_grupos_whatsapp_para_select()
+
+			self.assertEqual(
+				opcoes,
+				[
+					{
+						"label": "Recepção (120363408543428156@g.us)",
+						"value": "120363408543428156@g.us",
+					}
+				],
+			)
+		finally:
+			whatsapp_utils.frappe.has_permission = original_has_permission
+			whatsapp_utils.listar_grupos_whatsapp = original_listar_grupos_whatsapp
+
+	def test_listar_grupos_whatsapp_para_select_exige_permissao(self):
+		original_has_permission = whatsapp_utils.frappe.has_permission
+
+		try:
+			whatsapp_utils.frappe.has_permission = lambda *args, **kwargs: False
+
+			with self.assertRaises(frappe.PermissionError):
+				whatsapp_utils.listar_grupos_whatsapp_para_select()
+		finally:
+			whatsapp_utils.frappe.has_permission = original_has_permission

--- a/gris/tests/test_recepcao_notificacoes.py
+++ b/gris/tests/test_recepcao_notificacoes.py
@@ -1,0 +1,114 @@
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from gris.api import recepcao_notificacoes
+
+
+class TestRecepcaoNotificacoes(FrappeTestCase):
+	def test_notificar_nova_manifestacao_envia_para_grupo_configurado(self):
+		original_get_single_value = recepcao_notificacoes.frappe.db.get_single_value
+		original_enviar_para_grupo = recepcao_notificacoes.enviar_para_grupo
+		original_today = recepcao_notificacoes.today
+
+		enviadas = []
+
+		def _fake_enviar_para_grupo(grupo_jid, mensagem, mencionar_todos=False):
+			enviadas.append(
+				{
+					"grupo_jid": grupo_jid,
+					"mensagem": mensagem,
+					"mencionar_todos": mencionar_todos,
+				}
+			)
+
+		try:
+			recepcao_notificacoes.frappe.db.get_single_value = lambda *args, **kwargs: (
+				"120363408543428156@g.us"
+			)
+			recepcao_notificacoes.enviar_para_grupo = _fake_enviar_para_grupo
+			recepcao_notificacoes.today = lambda: "2026-04-14"
+
+			recepcao_notificacoes.notificar_nova_manifestacao_no_grupo_recepcao(
+				nome_jovem="Joao da Silva",
+				nome_responsavel="Maria da Silva",
+				data_nascimento_jovem="2015-04-14",
+				contexto="teste",
+			)
+
+			self.assertEqual(len(enviadas), 1)
+			self.assertEqual(enviadas[0]["grupo_jid"], "120363408543428156@g.us")
+			self.assertTrue(enviadas[0]["mencionar_todos"])
+			self.assertIn("@todos", enviadas[0]["mensagem"])
+			self.assertIn("Joao da Silva", enviadas[0]["mensagem"])
+			self.assertIn("Maria da Silva", enviadas[0]["mensagem"])
+			self.assertIn("11 anos", enviadas[0]["mensagem"])
+		finally:
+			recepcao_notificacoes.frappe.db.get_single_value = original_get_single_value
+			recepcao_notificacoes.enviar_para_grupo = original_enviar_para_grupo
+			recepcao_notificacoes.today = original_today
+
+	def test_notificar_nova_manifestacao_nao_envia_sem_grupo_configurado(self):
+		original_get_single_value = recepcao_notificacoes.frappe.db.get_single_value
+		original_enviar_para_grupo = recepcao_notificacoes.enviar_para_grupo
+
+		enviadas = []
+
+		def _fake_enviar_para_grupo(grupo_jid, mensagem, mencionar_todos=False):
+			enviadas.append(
+				{
+					"grupo_jid": grupo_jid,
+					"mensagem": mensagem,
+					"mencionar_todos": mencionar_todos,
+				}
+			)
+
+		try:
+			recepcao_notificacoes.frappe.db.get_single_value = lambda *args, **kwargs: ""
+			recepcao_notificacoes.enviar_para_grupo = _fake_enviar_para_grupo
+
+			recepcao_notificacoes.notificar_nova_manifestacao_no_grupo_recepcao(
+				nome_jovem="Joao",
+				nome_responsavel="Maria",
+				data_nascimento_jovem="2015-04-14",
+				contexto="teste",
+			)
+
+			self.assertEqual(enviadas, [])
+		finally:
+			recepcao_notificacoes.frappe.db.get_single_value = original_get_single_value
+			recepcao_notificacoes.enviar_para_grupo = original_enviar_para_grupo
+
+	def test_notificar_nova_manifestacao_usa_fallback_sem_data_valida(self):
+		original_get_single_value = recepcao_notificacoes.frappe.db.get_single_value
+		original_enviar_para_grupo = recepcao_notificacoes.enviar_para_grupo
+
+		enviadas = []
+
+		def _fake_enviar_para_grupo(grupo_jid, mensagem, mencionar_todos=False):
+			enviadas.append(
+				{
+					"grupo_jid": grupo_jid,
+					"mensagem": mensagem,
+					"mencionar_todos": mencionar_todos,
+				}
+			)
+
+		try:
+			recepcao_notificacoes.frappe.db.get_single_value = lambda *args, **kwargs: (
+				"120363408543428156@g.us"
+			)
+			recepcao_notificacoes.enviar_para_grupo = _fake_enviar_para_grupo
+
+			recepcao_notificacoes.notificar_nova_manifestacao_no_grupo_recepcao(
+				nome_jovem="Joao",
+				nome_responsavel="Maria",
+				data_nascimento_jovem="invalida",
+				contexto="teste",
+			)
+
+			self.assertEqual(len(enviadas), 1)
+			self.assertTrue(enviadas[0]["mencionar_todos"])
+			self.assertIn("*Idade do jovem*: não informada.", enviadas[0]["mensagem"])
+		finally:
+			recepcao_notificacoes.frappe.db.get_single_value = original_get_single_value
+			recepcao_notificacoes.enviar_para_grupo = original_enviar_para_grupo

--- a/gris/utils/whatsapp.py
+++ b/gris/utils/whatsapp.py
@@ -101,6 +101,51 @@ def _post(endpoint: str, payload: dict, *, config: dict | None = None) -> dict:
 	raise WhatsAppRequestError("Número máximo de tentativas atingido.")  # pragma: no cover
 
 
+def _get(
+	endpoint: str,
+	*,
+	params: dict | None = None,
+	config: dict | None = None,
+) -> dict | list:
+	"""Executa GET na Evolution API com retry automático para erros transitórios."""
+	if config is None:
+		config = _get_config()
+
+	url = f"{config['url_api']}{endpoint}"
+	headers = _build_headers(config["api_key"])
+	logger = _logger()
+
+	for attempt in range(1, MAX_RETRIES + 1):
+		try:
+			response = requests.get(url, headers=headers, params=params, timeout=DEFAULT_TIMEOUT)
+		except requests.RequestException as exc:
+			raise WhatsAppRequestError(f"Falha de conexão ao chamar Evolution API: {exc}") from exc
+
+		if response.status_code < 400:
+			try:
+				return response.json()
+			except ValueError as exc:
+				raise WhatsAppRequestError(
+					"Evolution API retornou resposta inválida ao buscar grupos."
+				) from exc
+
+		if response.status_code not in RETRYABLE_STATUS_CODES or attempt == MAX_RETRIES:
+			try:
+				detail = response.json()
+			except ValueError:
+				detail = response.text or "Sem detalhes."
+			raise WhatsAppRequestError(
+				f"Evolution API retornou HTTP {response.status_code}: {detail}"
+			)
+
+		logger.warning(
+			f"Evolution API HTTP {response.status_code} na tentativa {attempt}/{MAX_RETRIES}. Retentando..."
+		)
+		time.sleep(2 ** (attempt - 1))
+
+	raise WhatsAppRequestError("Número máximo de tentativas atingido.")  # pragma: no cover
+
+
 def _registrar_sucesso() -> None:
 	frappe.db.set_single_value(SETTINGS_DOCTYPE, {"ultimo_envio_em": now_datetime(), "ultimo_erro": ""})
 	frappe.db.commit()
@@ -158,9 +203,16 @@ def _enviar_midia_sync(numero: str, tipo: str, url_ou_base64: str, caption: str 
 	return result
 
 
-def _enviar_para_grupo_sync(grupo_jid: str, mensagem: str) -> dict:
+def _enviar_para_grupo_sync(
+	grupo_jid: str,
+	mensagem: str,
+	*,
+	mencionar_todos: bool = False,
+) -> dict:
 	config = _get_config()
 	payload = {"number": grupo_jid, "text": mensagem}
+	if mencionar_todos:
+		payload["mentionsEveryOne"] = True
 
 	try:
 		result = _post(f"/message/sendText/{config['nome_instancia']}", payload, config=config)
@@ -200,6 +252,64 @@ def _enviar_mensagem_formatada_sync(
 
 
 # ─── API Pública ──────────────────────────────────────────────────────────────
+
+
+def listar_grupos_whatsapp(*, get_participants: bool = False) -> list[dict[str, str]]:
+	"""Lista os grupos da instância WhatsApp conectada na Evolution API.
+
+	Args:
+		get_participants: Quando True, solicita também os participantes no endpoint da Evolution.
+
+	Returns:
+		Lista de grupos no formato [{"id": "...@g.us", "subject": "Nome do grupo"}].
+
+	Raises:
+		WhatsAppConfigurationError: Integração desabilitada ou configuração incompleta.
+		WhatsAppRequestError: Falha de rede, HTTP ou payload inválido ao chamar a Evolution API.
+	"""
+	config = _get_config()
+	params = {"getParticipants": str(bool(get_participants)).lower()}
+	result = _get(
+		f"/group/fetchAllGroups/{config['nome_instancia']}",
+		params=params,
+		config=config,
+	)
+
+	if not isinstance(result, list):
+		raise WhatsAppRequestError("Formato inválido na resposta de listagem de grupos.")
+
+	grupos: list[dict[str, str]] = []
+	for item in result:
+		if not isinstance(item, dict):
+			continue
+
+		grupo_id = str(item.get("id") or "").strip()
+		if not grupo_id:
+			continue
+
+		subject = str(item.get("subject") or "").strip()
+		grupos.append({"id": grupo_id, "subject": subject or grupo_id})
+
+	return sorted(grupos, key=lambda grupo: grupo["subject"].casefold())
+
+
+@frappe.whitelist()
+def listar_grupos_whatsapp_para_select() -> list[dict[str, str]]:
+	"""Retorna opções de grupos WhatsApp para uso em campos Select no Desk."""
+	if not frappe.has_permission("Configuracoes de Recepcao", ptype="write"):
+		frappe.throw(
+			"Sem permissão para editar Configurações de Recepção.",
+			frappe.PermissionError,
+		)
+
+	grupos = listar_grupos_whatsapp()
+	return [
+		{
+			"label": f"{grupo['subject']} ({grupo['id']})",
+			"value": grupo["id"],
+		}
+		for grupo in grupos
+	]
 
 
 def enviar_texto(numero: str, mensagem: str, *, enqueue: bool = True) -> dict | None:
@@ -267,12 +377,19 @@ def enviar_midia(
 	return _enviar_midia_sync(numero, tipo, url_ou_base64, caption)
 
 
-def enviar_para_grupo(grupo_jid: str, mensagem: str, *, enqueue: bool = True) -> dict | None:
+def enviar_para_grupo(
+	grupo_jid: str,
+	mensagem: str,
+	*,
+	mencionar_todos: bool = False,
+	enqueue: bool = True,
+) -> dict | None:
 	"""Envia mensagem de texto para um grupo WhatsApp.
 
 	Args:
 		grupo_jid: JID do grupo no formato Evolution API (ex.: "5511999999999-1234567890@g.us").
 		mensagem: Texto a enviar.
+		mencionar_todos: Quando True, envia com menção geral para todos os participantes do grupo.
 		enqueue: Se True (padrão), processa em background.
 
 	Returns:
@@ -289,9 +406,14 @@ def enviar_para_grupo(grupo_jid: str, mensagem: str, *, enqueue: bool = True) ->
 			timeout=60,
 			grupo_jid=grupo_jid,
 			mensagem=mensagem,
+			mencionar_todos=mencionar_todos,
 		)
 		return None
-	return _enviar_para_grupo_sync(grupo_jid, mensagem)
+	return _enviar_para_grupo_sync(
+		grupo_jid,
+		mensagem,
+		mencionar_todos=mencionar_todos,
+	)
 
 
 def enviar_mensagem_formatada(

--- a/gris/www/manifestacao_interesse/index.py
+++ b/gris/www/manifestacao_interesse/index.py
@@ -6,6 +6,7 @@ from frappe import _
 from frappe.utils import now
 
 from gris.api.portal_cache_utils import get_uel_cached
+from gris.api.recepcao_notificacoes import notificar_nova_manifestacao_no_grupo_recepcao
 
 
 def get_context(context):
@@ -45,6 +46,7 @@ def submit_interest(
 			jovens_list = jovens or []
 
 		last_resposta = None
+		novos_associados_criados: list[dict[str, str]] = []
 		for jovem in jovens_list:
 			resposta = frappe.get_doc(
 				{
@@ -100,6 +102,7 @@ def submit_interest(
 		for jovem in jovens_list:
 			# Create or Get Novo Associado
 			novo_associado_doc = None
+			novo_associado_criado = False
 			cpf_jovem = jovem.get("cpf_jovem")
 			if cpf_jovem:
 				existing_jovem = frappe.db.exists("Novo Associado", {"cpf": cpf_jovem})
@@ -115,6 +118,7 @@ def submit_interest(
 						}
 					)
 					novo_associado_doc.insert(ignore_permissions=True)
+					novo_associado_criado = True
 
 			# Create Responsavel Vinculo
 			if responsavel_doc and novo_associado_doc:
@@ -136,6 +140,14 @@ def submit_interest(
 						}
 					)
 					vinculo.insert(ignore_permissions=True)
+
+			if novo_associado_criado:
+				novos_associados_criados.append(
+					{
+						"nome_jovem": str(jovem.get("nome_jovem") or ""),
+						"data_nascimento_jovem": str(jovem.get("data_nascimento_jovem") or ""),
+					}
+				)
 
 		# Send welcome email manually to suppress "Welcome email sent" message
 		try:
@@ -160,6 +172,14 @@ def submit_interest(
 				frappe.log_error("DEBUG EMAIL SUCCESS", f"Email sent to {email_responsavel}")
 			except Exception as e:
 				frappe.log_error("DEBUG EMAIL ERROR", str(e))
+
+		for payload in novos_associados_criados:
+			notificar_nova_manifestacao_no_grupo_recepcao(
+				nome_jovem=payload.get("nome_jovem") or "",
+				nome_responsavel=nome_responsavel,
+				data_nascimento_jovem=payload.get("data_nascimento_jovem"),
+				contexto="manifestacao_interesse",
+			)
 
 		return {
 			"status": "success",

--- a/gris/www/responsavel/beneficiarios.py
+++ b/gris/www/responsavel/beneficiarios.py
@@ -4,6 +4,7 @@ import frappe
 from frappe.utils import add_days, cint, getdate, now, today
 
 from gris.api.portal_access import enrich_context
+from gris.api.recepcao_notificacoes import notificar_nova_manifestacao_no_grupo_recepcao
 
 no_cache = 1
 
@@ -148,7 +149,8 @@ def get_context(context):
 			"tipo_de_registro",
 			"visita_agendada",
 			"primeira_visita_realizada",
-		] + list(field_interval_map.keys())
+			*field_interval_map.keys(),
+		]
 
 		beneficiarios_integracao = frappe.get_all(
 			"Novo Associado", filters={"name": ["in", novo_associado_names]}, fields=fields_to_fetch
@@ -540,6 +542,13 @@ def adicionar_beneficiario(nome_jovem, cpf_jovem, data_nascimento_jovem):
 				"beneficiario_novo_associado": novo_associado_doc.name,
 			}
 		).insert(ignore_permissions=True)
+
+		notificar_nova_manifestacao_no_grupo_recepcao(
+			nome_jovem=nome_jovem,
+			nome_responsavel=responsavel_doc.nome_completo or responsavel_name,
+			data_nascimento_jovem=data_nascimento_jovem,
+			contexto="adicionar_beneficiario",
+		)
 
 		return {"ok": True, "message": "Beneficiário adicionado com sucesso!"}
 

--- a/gris/www/responsavel/registro.py
+++ b/gris/www/responsavel/registro.py
@@ -61,7 +61,7 @@ def get_context(context):
 			resp_doc = frappe.get_doc("Responsavel", v.responsavel)
 			responsaveis.append({"vinculo": v, "doc": resp_doc})
 
-	responsaveis.sort(key=lambda x: (x["doc"].nome_completo or ""))
+	responsaveis.sort(key=lambda x: x["doc"].nome_completo or "")
 
 	# Ensure at least 2 items for the UI
 	while len(responsaveis) < 2:
@@ -377,7 +377,9 @@ def update_novo_associado(novo_associado_name, data, responsaveis_data=None):
 	if guarda_unilateral:
 		guardioes = [v for v in all_vinculos if cint(v.get("\u00e9_guardiao_legal")) == 1]
 		if len(guardioes) != 1:
-			frappe.throw("Com guarda unilateral, exatamente um responsável deve ser marcado como guardião legal.")
+			frappe.throw(
+				"Com guarda unilateral, exatamente um responsável deve ser marcado como guardião legal."
+			)
 	else:
 		for v in all_vinculos:
 			if cint(v.get("\u00e9_guardiao_legal")) != 1:


### PR DESCRIPTION
This pull request introduces new functionality for notifying the WhatsApp reception group when a new interest manifestation is registered, improves WhatsApp group integration, and adds automated tests for these features. The main changes are the addition of a configurable WhatsApp group field, backend and frontend integration for group selection, new notification logic, and comprehensive tests to ensure reliability.

**WhatsApp Group Integration and Notification:**

* Added a new section and field (`grupo_recepcao_whatsapp`) to the `Configuracoes de Recepcao` DocType for selecting the WhatsApp group used for reception notifications. The field options are dynamically loaded from the connected WhatsApp instance. [[1]](diffhunk://#diff-78e5a00677a572ea2a3f777a61e9a1942ed67c1638af0fa455e467da354444a7L24-R26) [[2]](diffhunk://#diff-78e5a00677a572ea2a3f777a61e9a1942ed67c1638af0fa455e467da354444a7R122-R132) [[3]](diffhunk://#diff-ecbd060d12502c13eef0d84f159804eb7e2991eb1c13f7492aba91c4f098f979L4-R59)
* Implemented backend support for listing WhatsApp groups via the Evolution API, including a whitelisted method for populating select options in the Desk UI. [[1]](diffhunk://#diff-327147b6754da19fca5f6dacd4578ceb74d23d91998b0e645c5d4cbc53fc8280R104-R148) [[2]](diffhunk://#diff-327147b6754da19fca5f6dacd4578ceb74d23d91998b0e645c5d4cbc53fc8280L161-R215)
* Updated the WhatsApp utility to support sending group messages with the "@todos" mention (`mencionar_todos`), both synchronously and asynchronously. [[1]](diffhunk://#diff-327147b6754da19fca5f6dacd4578ceb74d23d91998b0e645c5d4cbc53fc8280L161-R215) [[2]](diffhunk://#diff-327147b6754da19fca5f6dacd4578ceb74d23d91998b0e645c5d4cbc53fc8280L270-R392) [[3]](diffhunk://#diff-327147b6754da19fca5f6dacd4578ceb74d23d91998b0e645c5d4cbc53fc8280R409-R416)

**Notification Logic:**

* Added the `notificar_nova_manifestacao_no_grupo_recepcao` function to `recepcao_notificacoes.py`, which sends a notification to the configured WhatsApp group when a new interest manifestation is registered. The notification includes the youth's name, responsible person's name, calculated age, and a link to the dashboard.
* Integrated this notification into the interest manifestation flow, ensuring the group is notified only when a new youth is actually created. [[1]](diffhunk://#diff-19ff09fb83dfde104159a4f956ac318715b091be65d0eca5dfd818fbfd1ff4edR9) [[2]](diffhunk://#diff-19ff09fb83dfde104159a4f956ac318715b091be65d0eca5dfd818fbfd1ff4edR49) [[3]](diffhunk://#diff-19ff09fb83dfde104159a4f956ac318715b091be65d0eca5dfd818fbfd1ff4edR105) [[4]](diffhunk://#diff-19ff09fb83dfde104159a4f956ac318715b091be65d0eca5dfd818fbfd1ff4edR121) [[5]](diffhunk://#diff-19ff09fb83dfde104159a4f956ac318715b091be65d0eca5dfd818fbfd1ff4edR144-R151)

**Testing:**

* Added automated tests for the WhatsApp group notification logic and group listing/select features, ensuring correct payloads, permission checks, and fallback behavior. [[1]](diffhunk://#diff-6506c80c723fc367c3ba8826f34d8fe335daeea12d12583ce4e47c3dafd3f201L4-R120) [[2]](diffhunk://#diff-2781a954d5390e2475563fb5f49c0e1abdc44214b24e87959b787adfe0d38b3cR1-R114)

These changes provide a robust and configurable way to keep the reception team informed of new interests via WhatsApp, with reliable integration and test coverage.