### PR TITLE
fix ui and ages of new users

### DIFF
--- a/gris/gris/doctype/novo_associado/novo_associado.py
+++ b/gris/gris/doctype/novo_associado/novo_associado.py
@@ -6,6 +6,7 @@ import re
 
 import frappe
 from frappe.model.document import Document
+from frappe.utils import getdate, today
 
 
 class NovoAssociado(Document):
@@ -13,6 +14,11 @@ class NovoAssociado(Document):
 		if self.cpf:
 			cpf_clean = re.sub(r"\D", "", self.cpf)
 			self.name = hashlib.md5(cpf_clean.encode("utf-8")).hexdigest()
+
+	def before_insert(self):
+		ramo = _ramo_por_data_de_nascimento(self.data_de_nascimento)
+		if ramo:
+			self.ramo = ramo
 
 	def on_trash(self):
 		"""Limpa referências em Responsavel Vinculo ao excluir Novo Associado."""
@@ -25,3 +31,39 @@ class NovoAssociado(Document):
 			frappe.db.set_value(
 				"Responsavel Vinculo", vinculo_name, "beneficiario_novo_associado", None
 			)
+
+
+def _ramo_por_data_de_nascimento(data_de_nascimento):
+	"""Retorna o ramo correspondente à idade decimal calculada da data de nascimento.
+
+	Usa as idades de transição definidas no Single ``Vagas`` como limite superior
+	de cada ramo: se a idade for maior que a idade de transição, o jovem é
+	promovido ao próximo ramo. O último ramo (Pioneiro) acolhe qualquer idade acima.
+	"""
+	if not data_de_nascimento:
+		return None
+
+	vagas = frappe.get_single("Vagas")
+	ramos = [
+		("Filhotes", float(vagas.idade_transicao_filhotes or 0)),
+		("Lobinho", float(vagas.idade_transicao_lobinho or 0)),
+		("Escoteiro", float(vagas.idade_transicao_escoteiro or 0)),
+		("Sênior", float(vagas.idade_transicao_senior or 0)),
+		("Pioneiro", float(vagas.idade_transicao_pioneiro or 0)),
+	]
+
+	nascimento = getdate(data_de_nascimento)
+	hoje = getdate(today())
+	anos = hoje.year - nascimento.year
+	meses = hoje.month - nascimento.month
+	if hoje.day < nascimento.day:
+		meses -= 1
+	if meses < 0:
+		anos -= 1
+		meses += 12
+	idade_decimal = anos + meses / 12
+
+	for nome, idade_transicao in ramos[:-1]:
+		if idade_decimal <= idade_transicao:
+			return nome
+	return ramos[-1][0]

--- a/gris/public/design_system/css/select.css
+++ b/gris/public/design_system/css/select.css
@@ -15,3 +15,55 @@
   max-height: 300px;
   overflow-y: auto;
 }
+
+/* ---------------------------------------------------------------
+   Popover: top layer + sem transição.
+
+   O JS dos componentes promove o [data-popover] ao top layer do
+   navegador via HTML Popover API (popover="manual" + showPopover()).
+   Isso faz o popover renderizar acima de qualquer elemento — inclusive
+   <dialog> abertos com showModal() — e isola o popover de ancestors
+   com `overflow: hidden` ou `transform`/`scale`/`translate` (que
+   estabelecem containing block para position:fixed).
+
+   Posicionamento é feito inline pelo JS via getBoundingClientRect();
+   aqui anulamos transições e transformações de entrada do upstream
+   para que o popover apareça instantaneamente no lugar calculado,
+   sem deslizar pela tela.
+   --------------------------------------------------------------- */
+[data-popover] {
+  position: fixed;
+  z-index: 60;
+  transition: none !important;
+  animation: none !important;
+  /* Reseta defaults da UA stylesheet aplicados pelo atributo `popover`
+     (inset: 0; margin: auto) que centralizariam o elemento no viewport.
+     O JS dos componentes seta top/bottom/left/right inline. */
+  inset: auto;
+  margin: 0;
+}
+
+/* Anula transformações de entrada/saída do upstream baseadas em
+   aria-hidden + data-side, que causavam o efeito "deslize" reportado. */
+[data-popover],
+[data-popover][aria-hidden="true"] {
+  scale: 1 !important;
+  translate: 0 0 !important;
+  --tw-scale-x: 100%;
+  --tw-scale-y: 100%;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+}
+
+/* Anula `left:0` / `right:0` do upstream (válidos para position:absolute);
+   coordenadas reais são setadas inline pelo JS com base no triggerRect. */
+[data-popover][data-align=start],
+[data-popover][data-align=end] {
+  left: auto;
+  right: auto;
+}
+
+/* Popover não usa backdrop nativo da Popover API. */
+[data-popover]::backdrop {
+  background: transparent;
+}

--- a/gris/public/design_system/js/components/dropdown-menu.js
+++ b/gris/public/design_system/js/components/dropdown-menu.js
@@ -18,6 +18,13 @@
     let menuItems = [];
     let activeIndex = -1;
 
+    // HTML Popover API: promove o popover ao top layer ao abrir, fazendo-o
+    // renderizar acima de qualquer elemento (sidebars, dialogs, etc.) e
+    // isolando-o de ancestors com `overflow: hidden` ou `transform`.
+    if (!popover.hasAttribute('popover')) {
+      popover.setAttribute('popover', 'manual');
+    }
+
     const positionPopover = () => {
       const GAP = 8;
       const vw = window.innerWidth;
@@ -25,46 +32,57 @@
       const triggerRect = trigger.getBoundingClientRect();
 
       // Mede dimensões naturais sem exibir (visibility:hidden + sem transições)
+      const previousVisibility = popover.style.visibility;
+      const previousTransition = popover.style.transition;
       popover.style.visibility = 'hidden';
       popover.style.transition = 'none';
-      popover.setAttribute('aria-hidden', 'false');
+      const wasHidden = popover.getAttribute('aria-hidden') !== 'false';
+      if (wasHidden) popover.setAttribute('aria-hidden', 'false');
       const contentW = popover.scrollWidth;
       const contentH = popover.scrollHeight;
-      popover.setAttribute('aria-hidden', 'true');
-      popover.style.removeProperty('visibility');
-      popover.style.removeProperty('transition');
+      if (wasHidden) popover.setAttribute('aria-hidden', 'true');
+      if (previousVisibility) popover.style.visibility = previousVisibility;
+      else popover.style.removeProperty('visibility');
+      if (previousTransition) popover.style.transition = previousTransition;
+      else popover.style.removeProperty('transition');
 
-      // Lado vertical: prefere baixo, inverte para cima se houver mais espaço
       const spaceBelow = vh - triggerRect.bottom - GAP;
       const spaceAbove = triggerRect.top - GAP;
       const side = (contentH > spaceBelow && spaceAbove > spaceBelow) ? 'top' : 'bottom';
       popover.setAttribute('data-side', side);
 
-      // Alinhamento horizontal: start (left:0, expande à direita) vs end (right:0, expande à esquerda)
       const spaceRight = vw - triggerRect.left - GAP;
       const spaceLeft = triggerRect.right - GAP;
-      if (contentW > spaceRight && spaceLeft > spaceRight) {
-        popover.setAttribute('data-align', 'end');
-      } else {
-        popover.setAttribute('data-align', 'start');
-      }
+      const align = (contentW > spaceRight && spaceLeft > spaceRight) ? 'end' : 'start';
+      popover.setAttribute('data-align', align);
 
-      // Altura máxima: restringe ao espaço disponível com scroll interno
       const availH = Math.max(side === 'bottom' ? spaceBelow : spaceAbove, 120);
-      if (contentH > availH) {
-        popover.style.maxHeight = `${availH}px`;
-      } else {
-        popover.style.removeProperty('max-height');
-      }
+      if (contentH > availH) popover.style.maxHeight = `${availH}px`;
+      else popover.style.removeProperty('max-height');
 
-      // Largura máxima: evita overflow do viewport
       const maxW = vw - 2 * GAP;
-      if (contentW > maxW) {
-        popover.style.maxWidth = `${maxW}px`;
+      if (contentW > maxW) popover.style.maxWidth = `${maxW}px`;
+      else popover.style.removeProperty('max-width');
+
+      // Coordenadas para position: fixed (relativas ao viewport)
+      if (side === 'bottom') {
+        popover.style.top = `${triggerRect.bottom + GAP}px`;
+        popover.style.removeProperty('bottom');
       } else {
-        popover.style.removeProperty('max-width');
+        popover.style.bottom = `${vh - triggerRect.top + GAP}px`;
+        popover.style.removeProperty('top');
       }
+      if (align === 'start') {
+        popover.style.left = `${triggerRect.left}px`;
+        popover.style.removeProperty('right');
+      } else {
+        popover.style.right = `${vw - triggerRect.right}px`;
+        popover.style.removeProperty('left');
+      }
+      popover.style.minWidth = `${triggerRect.width}px`;
     };
+
+    const onReposition = () => positionPopover();
 
     const closePopover = (focusOnTrigger = true) => {
       if (trigger.getAttribute('aria-expanded') === 'false') return;
@@ -73,11 +91,21 @@
       popover.setAttribute('aria-hidden', 'true');
       popover.style.removeProperty('max-height');
       popover.style.removeProperty('max-width');
-      
+      popover.style.removeProperty('top');
+      popover.style.removeProperty('bottom');
+      popover.style.removeProperty('left');
+      popover.style.removeProperty('right');
+      popover.style.removeProperty('min-width');
+      window.removeEventListener('scroll', onReposition, true);
+      window.removeEventListener('resize', onReposition);
+      if (popover.matches(':popover-open')) {
+        popover.hidePopover();
+      }
+
       if (focusOnTrigger) {
         trigger.focus();
       }
-      
+
       setActiveItem(-1);
     };
 
@@ -86,15 +114,18 @@
         detail: { source: dropdownMenuComponent }
       }));
 
+      if (!popover.matches(':popover-open')) {
+        popover.showPopover();
+      }
       positionPopover();
 
       trigger.setAttribute('aria-expanded', 'true');
       popover.setAttribute('aria-hidden', 'false');
-      menuItems = Array.from(menu.querySelectorAll('[role^="menuitem"]')).filter(item => 
-        !item.hasAttribute('disabled') && 
+      menuItems = Array.from(menu.querySelectorAll('[role^="menuitem"]')).filter(item =>
+        !item.hasAttribute('disabled') &&
         item.getAttribute('aria-disabled') !== 'true'
       );
-      
+
       if (menuItems.length > 0 && initialSelection) {
         if (initialSelection === 'first') {
           setActiveItem(0);
@@ -102,6 +133,9 @@
           setActiveItem(menuItems.length - 1);
         }
       }
+
+      window.addEventListener('scroll', onReposition, true);
+      window.addEventListener('resize', onReposition);
     };
 
     const setActiveItem = (index) => {

--- a/gris/public/design_system/js/components/phone-input.js
+++ b/gris/public/design_system/js/components/phone-input.js
@@ -86,50 +86,9 @@
         updateHidden();
       });
 
-      const popover = country.querySelector("[data-popover]");
-      if (popover) {
-        const VIEWPORT_MARGIN = 8;
-        const MIN_HEIGHT = 160;
-
-        const adjustPopoverPlacement = () => {
-          if (popover.getAttribute("aria-hidden") === "true") return;
-
-          const triggerRect = trigger.getBoundingClientRect();
-          const spaceBelow = window.innerHeight - triggerRect.bottom - VIEWPORT_MARGIN;
-          const spaceAbove = triggerRect.top - VIEWPORT_MARGIN;
-          const openUp = spaceAbove > spaceBelow && spaceBelow < MIN_HEIGHT;
-          const available = Math.max(openUp ? spaceAbove : spaceBelow, MIN_HEIGHT);
-
-          popover.style.top = "";
-          popover.style.bottom = "";
-          if (openUp) {
-            popover.style.bottom = "100%";
-            popover.dataset.side = "top";
-          } else {
-            popover.style.top = "100%";
-            popover.dataset.side = "bottom";
-          }
-          popover.style.maxHeight = `${available}px`;
-        };
-
-        const popoverObserver = new MutationObserver(() => {
-          if (popover.getAttribute("aria-hidden") === "false") {
-            adjustPopoverPlacement();
-          }
-        });
-        popoverObserver.observe(popover, {
-          attributes: true,
-          attributeFilter: ["aria-hidden"],
-        });
-
-        const onViewportChange = () => {
-          if (popover.getAttribute("aria-hidden") === "false") {
-            adjustPopoverPlacement();
-          }
-        };
-        window.addEventListener("resize", onViewportChange);
-        window.addEventListener("scroll", onViewportChange, true);
-      }
+      // Posicionamento do popover do seletor de país é gerenciado pelo
+      // próprio select.js (HTML Popover API + position:fixed com coordenadas
+      // calculadas a partir do triggerRect). Override redundante removido.
 
       // Public API
       Object.defineProperty(root, "value", {

--- a/gris/public/design_system/js/components/popover.js
+++ b/gris/public/design_system/js/components/popover.js
@@ -11,6 +11,15 @@
       return;
     }
 
+    // HTML Popover API: promove o content ao top layer ao abrir, fazendo-o
+    // renderizar acima de qualquer elemento (incluindo <dialog> em showModal)
+    // e isolando-o de ancestors com `overflow: hidden` ou
+    // `transform`/`translate`/`scale` (que estabeleceriam novo containing
+    // block para position:fixed).
+    if (!content.hasAttribute('popover')) {
+      content.setAttribute('popover', 'manual');
+    }
+
     const positionPopover = () => {
       const GAP = 8;
       const vw = window.innerWidth;
@@ -33,14 +42,11 @@
       const side = (contentH > spaceBelow && spaceAbove > spaceBelow) ? 'top' : 'bottom';
       content.setAttribute('data-side', side);
 
-      // Alinhamento horizontal: start (left:0, expande à direita) vs end (right:0, expande à esquerda)
+      // Alinhamento horizontal: start (alinhado à esquerda do trigger) vs end (alinhado à direita)
       const spaceRight = vw - triggerRect.left - GAP;
       const spaceLeft = triggerRect.right - GAP;
-      if (contentW > spaceRight && spaceLeft > spaceRight) {
-        content.setAttribute('data-align', 'end');
-      } else {
-        content.setAttribute('data-align', 'start');
-      }
+      const align = (contentW > spaceRight && spaceLeft > spaceRight) ? 'end' : 'start';
+      content.setAttribute('data-align', align);
 
       // Altura máxima: restringe ao espaço disponível com scroll interno
       const availH = Math.max(side === 'bottom' ? spaceBelow : spaceAbove, 120);
@@ -57,7 +63,26 @@
       } else {
         content.style.removeProperty('max-width');
       }
+
+      // Materializa coordenadas (position: fixed → relativas ao viewport)
+      if (side === 'bottom') {
+        content.style.top = `${triggerRect.bottom + GAP}px`;
+        content.style.removeProperty('bottom');
+      } else {
+        content.style.bottom = `${vh - triggerRect.top + GAP}px`;
+        content.style.removeProperty('top');
+      }
+      if (align === 'start') {
+        content.style.left = `${triggerRect.left}px`;
+        content.style.removeProperty('right');
+      } else {
+        content.style.right = `${vw - triggerRect.right}px`;
+        content.style.removeProperty('left');
+      }
+      content.style.minWidth = `${triggerRect.width}px`;
     };
+
+    const onReposition = () => positionPopover();
 
     const closePopover = (focusOnTrigger = true) => {
       if (trigger.getAttribute('aria-expanded') === 'false') return;
@@ -65,6 +90,16 @@
       content.setAttribute('aria-hidden', 'true');
       content.style.removeProperty('max-height');
       content.style.removeProperty('max-width');
+      content.style.removeProperty('top');
+      content.style.removeProperty('bottom');
+      content.style.removeProperty('left');
+      content.style.removeProperty('right');
+      content.style.removeProperty('min-width');
+      window.removeEventListener('scroll', onReposition, true);
+      window.removeEventListener('resize', onReposition);
+      if (content.matches(':popover-open')) {
+        content.hidePopover();
+      }
       if (focusOnTrigger) {
         trigger.focus();
       }
@@ -75,17 +110,26 @@
         detail: { source: popoverComponent }
       }));
 
+      // Promove ao top layer antes de medir/posicionar; o navegador
+      // automaticamente remove o `display: none` do estado fechado.
+      if (!content.matches(':popover-open')) {
+        content.showPopover();
+      }
+
       positionPopover();
 
       const elementToFocus = content.querySelector('[autofocus]');
       if (elementToFocus) {
-        content.addEventListener('transitionend', () => {
-          elementToFocus.focus();
-        }, { once: true });
+        elementToFocus.focus();
       }
 
       trigger.setAttribute('aria-expanded', 'true');
       content.setAttribute('aria-hidden', 'false');
+
+      // Reposicionar enquanto aberto: scroll (capture pega scrolls internos
+      // como o body de um <dialog>) e resize do viewport.
+      window.addEventListener('scroll', onReposition, true);
+      window.addEventListener('resize', onReposition);
     };
 
     trigger.addEventListener('click', () => {
@@ -97,11 +141,14 @@
       }
     });
 
-    popoverComponent.addEventListener('keydown', (event) => {
-      if (event.key === 'Escape') {
-        closePopover();
-      }
-    });
+    // Escape: trigger fica em popoverComponent; o content também recebe
+    // listener próprio para casos em que o foco está em elementos internos
+    // (ex.: input de busca).
+    const onKeydown = (event) => {
+      if (event.key === 'Escape') closePopover();
+    };
+    popoverComponent.addEventListener('keydown', onKeydown);
+    content.addEventListener('keydown', onKeydown);
 
     document.addEventListener('click', (event) => {
       if (!popoverComponent.contains(event.target)) {

--- a/gris/public/design_system/js/components/select.js
+++ b/gris/public/design_system/js/components/select.js
@@ -32,6 +32,74 @@
       return;
     }
 
+    // HTML Popover API: promove o popover ao top layer ao abrir, fazendo-o
+    // renderizar acima de qualquer elemento (incluindo <dialog> em showModal)
+    // e isolando-o de ancestors com `overflow: hidden` ou
+    // `transform`/`translate`/`scale` (que estabeleceriam novo containing
+    // block para position:fixed).
+    if (!popover.hasAttribute('popover')) {
+      popover.setAttribute('popover', 'manual');
+    }
+
+    const positionPopover = () => {
+      const GAP = 8;
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      const triggerRect = trigger.getBoundingClientRect();
+
+      // Mede dimensões naturais sem exibir
+      const previousVisibility = popover.style.visibility;
+      const previousTransition = popover.style.transition;
+      popover.style.visibility = 'hidden';
+      popover.style.transition = 'none';
+      const wasHidden = popover.getAttribute('aria-hidden') !== 'false';
+      if (wasHidden) popover.setAttribute('aria-hidden', 'false');
+      const contentW = popover.scrollWidth;
+      const contentH = popover.scrollHeight;
+      if (wasHidden) popover.setAttribute('aria-hidden', 'true');
+      if (previousVisibility) popover.style.visibility = previousVisibility;
+      else popover.style.removeProperty('visibility');
+      if (previousTransition) popover.style.transition = previousTransition;
+      else popover.style.removeProperty('transition');
+
+      const spaceBelow = vh - triggerRect.bottom - GAP;
+      const spaceAbove = triggerRect.top - GAP;
+      const side = (contentH > spaceBelow && spaceAbove > spaceBelow) ? 'top' : 'bottom';
+      popover.setAttribute('data-side', side);
+
+      const spaceRight = vw - triggerRect.left - GAP;
+      const spaceLeft = triggerRect.right - GAP;
+      const align = (contentW > spaceRight && spaceLeft > spaceRight) ? 'end' : 'start';
+      popover.setAttribute('data-align', align);
+
+      const availH = Math.max(side === 'bottom' ? spaceBelow : spaceAbove, 120);
+      if (contentH > availH) popover.style.maxHeight = `${availH}px`;
+      else popover.style.removeProperty('max-height');
+
+      const maxW = vw - 2 * GAP;
+      if (contentW > maxW) popover.style.maxWidth = `${maxW}px`;
+      else popover.style.removeProperty('max-width');
+
+      // Coordenadas para position: fixed (relativas ao viewport)
+      if (side === 'bottom') {
+        popover.style.top = `${triggerRect.bottom + GAP}px`;
+        popover.style.removeProperty('bottom');
+      } else {
+        popover.style.bottom = `${vh - triggerRect.top + GAP}px`;
+        popover.style.removeProperty('top');
+      }
+      if (align === 'start') {
+        popover.style.left = `${triggerRect.left}px`;
+        popover.style.removeProperty('right');
+      } else {
+        popover.style.right = `${vw - triggerRect.right}px`;
+        popover.style.removeProperty('left');
+      }
+      popover.style.minWidth = `${triggerRect.width}px`;
+    };
+
+    const onReposition = () => positionPopover();
+
     const allOptions = Array.from(listbox.querySelectorAll('[role="option"]'));
     const options = allOptions.filter(opt => opt.getAttribute('aria-disabled') !== 'true');
     let visibleOptions = [...options];
@@ -128,6 +196,21 @@
         } else {
           resetFilter();
         }
+      }
+
+      // Limpa coordenadas inline e listeners de reposicionamento, e remove
+      // o popover do top layer via Popover API.
+      popover.style.removeProperty('top');
+      popover.style.removeProperty('bottom');
+      popover.style.removeProperty('left');
+      popover.style.removeProperty('right');
+      popover.style.removeProperty('min-width');
+      popover.style.removeProperty('max-height');
+      popover.style.removeProperty('max-width');
+      window.removeEventListener('scroll', onReposition, true);
+      window.removeEventListener('resize', onReposition);
+      if (popover.matches(':popover-open')) {
+        popover.hidePopover();
       }
 
       if (focusOnTrigger) trigger.focus();
@@ -339,6 +422,13 @@
         detail: { source: selectComponent }
       }));
 
+      // Promove ao top layer antes de medir/posicionar; o navegador
+      // automaticamente remove o `display: none` do estado fechado.
+      if (!popover.matches(':popover-open')) {
+        popover.showPopover();
+      }
+      positionPopover();
+
       if (filter) {
         if (hasTransition()) {
           popover.addEventListener('transitionend', () => {
@@ -357,6 +447,11 @@
         setActiveOption(options.indexOf(selectedOption));
         selectedOption.scrollIntoView({ block: 'nearest' });
       }
+
+      // Reposicionar enquanto aberto: scroll com capture pega scroll do body
+      // do <dialog> ou de qualquer container; resize cobre redimensionamento.
+      window.addEventListener('scroll', onReposition, true);
+      window.addEventListener('resize', onReposition);
     };
 
     addListener(trigger, 'click', () => {
@@ -452,6 +547,13 @@
     selectComponent.__basecoatSelectCleanup = () => {
       if (listenerController) {
         listenerController.abort();
+      }
+      // Garante que o popover saia do top layer caso o select seja
+      // re-inicializado ou removido enquanto aberto.
+      window.removeEventListener('scroll', onReposition, true);
+      window.removeEventListener('resize', onReposition);
+      if (popover.matches(':popover-open')) {
+        popover.hidePopover();
       }
     };
     selectComponent.dataset.selectInitialized = true;

--- a/gris/www/recepcao/visao_geral.css
+++ b/gris/www/recepcao/visao_geral.css
@@ -399,6 +399,19 @@ dialog.dialog > div > section {
 	width: 100%;
 }
 
+/* Dialogs com formulário: garantir respiro mínimo no body, para que
+   campos e ações não fiquem apertados. Não aplicamos altura mínima a
+   todos os dialogs do design system para não regredir aqueles que já
+   abrem em tamanho equilibrado (ex.: confirmações curtas). */
+#modalNovoContato,
+#modalConversaInicial {
+	min-height: 55vh;
+}
+
+#modalAgendarVisita {
+	min-height: 32vh;
+}
+
 /* Responsivo ------------------------------------------------------*/
 @media (max-width: 768px) {
 	.kanban-column {


### PR DESCRIPTION
This pull request introduces a major refactor and improvement to the popover and dropdown positioning system across the design system components. The main goal is to consistently use the HTML Popover API to promote popovers to the browser’s top layer, ensuring they render above all other elements (including modals and elements with `overflow: hidden` or transforms), and to manage their positioning with precise, fixed coordinates. This change eliminates previous visual glitches, such as sliding transitions or popovers being clipped by ancestor containers, and unifies the code for popover management across components. Additionally, the popover positioning logic in the phone input component is now delegated to the select component, removing redundant code.

The most important changes are:

**Popover API adoption and positioning refactor:**
* All popover components (`select.js`, `dropdown-menu.js`, `popover.js`) now use the HTML Popover API (`popover="manual"` + `showPopover()`/`hidePopover()`) to promote popovers to the top layer, ensuring proper stacking and isolation from ancestor styles. Positioning is now always done with `position: fixed` and inline coordinates, calculated relative to the trigger element. [[1]](diffhunk://#diff-03c0f4ef6bc8d6a500f41d93c3d9ea82b248796c49eb6721b727c7e6507fcf5bR35-R102) [[2]](diffhunk://#diff-34ab21e0c59bcb7fc05f6d81f14e66a30dd872c1605da67e4cb1816e51690ce5R21-R103) [[3]](diffhunk://#diff-913f146072fcb2dafbea06fe6ab84005c7a53b485c9a81e30a87e798fd9460c7R14-R22)

* The popover positioning logic has been unified: the code now measures the popover’s natural size, calculates available space around the trigger, and sets the popover’s side (top/bottom) and alignment (start/end) accordingly. Inline styles for `top`, `bottom`, `left`, `right`, and `min-width` are set for precise placement, and are cleaned up on close. Listeners for `scroll` and `resize` keep the popover correctly positioned while open. [[1]](diffhunk://#diff-03c0f4ef6bc8d6a500f41d93c3d9ea82b248796c49eb6721b727c7e6507fcf5bR35-R102) [[2]](diffhunk://#diff-34ab21e0c59bcb7fc05f6d81f14e66a30dd872c1605da67e4cb1816e51690ce5R21-R103) [[3]](diffhunk://#diff-913f146072fcb2dafbea06fe6ab84005c7a53b485c9a81e30a87e798fd9460c7L36-R49) [[4]](diffhunk://#diff-913f146072fcb2dafbea06fe6ab84005c7a53b485c9a81e30a87e798fd9460c7R66-R102) [[5]](diffhunk://#diff-03c0f4ef6bc8d6a500f41d93c3d9ea82b248796c49eb6721b727c7e6507fcf5bR201-R215) [[6]](diffhunk://#diff-34ab21e0c59bcb7fc05f6d81f14e66a30dd872c1605da67e4cb1816e51690ce5R136-R138) [[7]](diffhunk://#diff-913f146072fcb2dafbea06fe6ab84005c7a53b485c9a81e30a87e798fd9460c7R113-R132) [[8]](diffhunk://#diff-03c0f4ef6bc8d6a500f41d93c3d9ea82b248796c49eb6721b727c7e6507fcf5bR425-R431)

**CSS adjustments:**
* The CSS for `[data-popover]` has been updated to remove all transitions and entry/exit transforms, making popovers appear instantly at their calculated position without sliding effects. It also removes default browser popover centering and disables the native backdrop.

**Component-specific improvements:**
* The phone input component (`phone-input.js`) now delegates popover positioning to the select component, removing its own redundant placement logic.

**Accessibility and event handling:**
* Escape key handling and focus management have been improved for popovers, ensuring that both the popover container and its content respond to keyboard events for accessibility.

Overall, these changes bring consistency, robustness, and improved user experience to all popover-based UI elements.