### PR TITLE
enhance ticket confirmation

### DIFF
--- a/gris/api/festas/convite_confirmado.py
+++ b/gris/api/festas/convite_confirmado.py
@@ -1,0 +1,172 @@
+"""API e helpers para a página pública /festas/convite_confirmado.
+
+Responsabilidades:
+- Gerar e validar tokens HMAC que protegem o acesso à página de confirmação.
+- Montar a `redirect_url` que a Infinitepay usa após o checkout.
+- Endpoint AJAX leve (`get_status`) para o polling do estado do pagamento.
+- Utilitários de segurança: mascarar e-mails e validar a `receipt_url` retornada
+  pela Infinitepay (evitando renderizar links arbitrários).
+
+A página em si (`gris.www.festas.convite_confirmado`) chama estes helpers no
+`get_context`. Nenhuma rota desta API dispara side-effects (envio de WhatsApp,
+e-mail, alteração de dados). Side-effects acontecem só no fluxo do webhook.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import re
+from urllib.parse import urlparse
+
+import frappe
+from frappe.rate_limiter import rate_limit
+from frappe.utils import get_url
+from frappe.utils.verified_command import get_secret
+
+CONVITE_NAME_RE = re.compile(r"^CF-\d{4}-\d+$")
+RECEIPT_URL_ALLOWED_HOSTS = {
+	"api.infinitepay.io",
+	"checkout.infinitepay.io",
+	"recibo.infinitepay.io",
+}
+TOKEN_PURPOSE = "convite_confirmado.v1"
+PAGE_PATH = "/festas/convite_confirmado"
+
+
+# ─── Validação / construção de identificador ──────────────────────────────────
+
+
+def _is_valid_convite_name(name: str | None) -> bool:
+	return bool(name) and bool(CONVITE_NAME_RE.match(name))
+
+
+def _build_token(convite_name: str) -> str:
+	"""HMAC-SHA256 do nome do convite usando o secret do site.
+
+	Determinístico (mesmo nome → mesmo token), o que é aceitável porque a página
+	sempre reflete o estado atual da cobrança — não há "ação" persistida no token.
+	"""
+	if not _is_valid_convite_name(convite_name):
+		raise ValueError("Invalid convite name")
+	message = f"{TOKEN_PURPOSE}:{convite_name}".encode()
+	return hmac.new(get_secret().encode(), message, hashlib.sha256).hexdigest()
+
+
+def _validate_token(convite_name: str | None, token: str | None) -> bool:
+	if not _is_valid_convite_name(convite_name) or not token:
+		return False
+	try:
+		expected = _build_token(convite_name)
+	except ValueError:
+		return False
+	return hmac.compare_digest(expected, token)
+
+
+def _build_redirect_url(convite_name: str) -> str:
+	"""URL absoluta para onde a Infinitepay redireciona após o pagamento."""
+	if not _is_valid_convite_name(convite_name):
+		raise ValueError("Invalid convite name")
+	token = _build_token(convite_name)
+	return f"{_site_base_url()}{PAGE_PATH}?c={convite_name}&t={token}"
+
+
+def _site_base_url() -> str:
+	"""Base URL do site, resiliente a contextos sem request HTTP completo.
+
+	`frappe.utils.get_url()` espera `frappe.local.request.host`; em jobs de
+	background ou testes com request stub, esse atributo pode não existir.
+	Tentamos o caminho normal e caímos no nome do site quando necessário.
+	"""
+	try:
+		return get_url()
+	except (AttributeError, TypeError):
+		conf = getattr(frappe.local, "conf", None) or {}
+		host_name = conf.get("host_name") or conf.get("hostname")
+		if host_name:
+			return host_name if host_name.startswith(("http://", "https://")) else f"http://{host_name}"
+		site = getattr(frappe.local, "site", "") or ""
+		protocol = "https://" if conf.get("ssl_certificate") else "http://"
+		return f"{protocol}{site}" if site else "http://127.0.0.1"
+
+
+# ─── Mascaramento / validação de URLs ─────────────────────────────────────────
+
+
+def _mask_email(email: str | None) -> str:
+	"""Retorna e-mail no formato 'a***@dominio.com'.
+
+	Conservador: se algo estiver fora do esperado, retorna string vazia para o
+	template, em vez de vazar o valor cru.
+	"""
+	if not email or "@" not in email:
+		return ""
+	local, _, domain = email.partition("@")
+	if not local or "." not in domain:
+		return ""
+	if len(local) <= 1:
+		mascara_local = f"{local}***"
+	else:
+		mascara_local = f"{local[0]}***"
+	return f"{mascara_local}@{domain}"
+
+
+def _is_safe_receipt_url(url: str | None) -> bool:
+	"""True quando a URL é HTTPS e aponta para domínio conhecido da Infinitepay."""
+	if not url:
+		return False
+	try:
+		parsed = urlparse(url)
+	except ValueError:
+		return False
+	if parsed.scheme != "https":
+		return False
+	host = (parsed.hostname or "").lower()
+	return host in RECEIPT_URL_ALLOWED_HOSTS
+
+
+# ─── Endpoint AJAX para polling ───────────────────────────────────────────────
+
+
+@frappe.whitelist(allow_guest=True)
+@rate_limit(key="convite-confirmado-status", limit=30, seconds=60)
+def get_status(c: str | None = None, t: str | None = None) -> dict:
+	"""Retorna apenas o status de pagamento + timestamp. Sem dados sensíveis.
+
+	Usado pelo polling client-side enquanto a página estiver em modo "aguardando".
+	"""
+	convite_name = (c or "").strip()
+	token = (t or "").strip()
+
+	if not _validate_token(convite_name, token):
+		frappe.local.response["http_status_code"] = 404
+		return {"status": "Indisponivel", "atualizado_em": None}
+
+	row = frappe.db.get_value(
+		"Convite Festa",
+		convite_name,
+		["cobranca_infinitepay", "modified"],
+		as_dict=True,
+	)
+	if not row:
+		frappe.local.response["http_status_code"] = 404
+		return {"status": "Indisponivel", "atualizado_em": None}
+
+	if not row.cobranca_infinitepay:
+		return {
+			"status": "Pendente",
+			"atualizado_em": row.modified.isoformat() if row.modified else None,
+		}
+
+	cobranca = frappe.db.get_value(
+		"Cobranca Infinitepay",
+		row.cobranca_infinitepay,
+		["status", "modified"],
+		as_dict=True,
+	) or {}
+	status = cobranca.get("status") or "Pendente"
+	modified = cobranca.get("modified")
+	return {
+		"status": status,
+		"atualizado_em": modified.isoformat() if modified else None,
+	}

--- a/gris/api/festas/test_convite_confirmado.py
+++ b/gris/api/festas/test_convite_confirmado.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2026, Grupo Escoteiro Professora Inah de Mello - 47/SP and Contributors
+# See license.txt
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from gris.api.festas.convite_confirmado import (
+	_build_redirect_url,
+	_build_token,
+	_is_safe_receipt_url,
+	_is_valid_convite_name,
+	_mask_email,
+	_validate_token,
+	get_status,
+)
+
+
+class TestConviteConfirmadoHelpers(FrappeTestCase):
+	def test_convite_name_validacao(self):
+		self.assertTrue(_is_valid_convite_name("CF-2026-00001"))
+		self.assertTrue(_is_valid_convite_name("CF-2030-99999"))
+		self.assertFalse(_is_valid_convite_name(""))
+		self.assertFalse(_is_valid_convite_name(None))
+		self.assertFalse(_is_valid_convite_name("XX-2026-00001"))
+		self.assertFalse(_is_valid_convite_name("CF-26-00001"))
+		self.assertFalse(_is_valid_convite_name("CF-2026"))
+		# Injeção de path / caracteres especiais
+		self.assertFalse(_is_valid_convite_name("CF-2026-1' OR '1'='1"))
+		self.assertFalse(_is_valid_convite_name("../etc/passwd"))
+
+	def test_token_valido_e_invalido(self):
+		nome = "CF-2026-00042"
+		token = _build_token(nome)
+		self.assertTrue(_validate_token(nome, token))
+		self.assertFalse(_validate_token(nome, ""))
+		self.assertFalse(_validate_token(nome, token + "x"))
+		# Token de outro convite não vale para este
+		outro = _build_token("CF-2026-00043")
+		self.assertFalse(_validate_token(nome, outro))
+		# Nome inválido sempre falha
+		self.assertFalse(_validate_token("XX-1", token))
+
+	def test_build_token_rejeita_nome_invalido(self):
+		with self.assertRaises(ValueError):
+			_build_token("XX-1")
+
+	def test_redirect_url_contem_token_assinado(self):
+		nome = "CF-2026-00777"
+		url = _build_redirect_url(nome)
+		self.assertIn("/festas/convite_confirmado?c=", url)
+		self.assertIn(f"c={nome}", url)
+		token_esperado = _build_token(nome)
+		self.assertIn(f"t={token_esperado}", url)
+
+	def test_receipt_url_allowlist(self):
+		self.assertTrue(_is_safe_receipt_url("https://recibo.infinitepay.io/abc"))
+		self.assertTrue(_is_safe_receipt_url("https://api.infinitepay.io/x/y"))
+		self.assertTrue(_is_safe_receipt_url("https://checkout.infinitepay.io/c/123"))
+		# Domínio externo é rejeitado
+		self.assertFalse(_is_safe_receipt_url("https://evil.com/redir?to=https://recibo.infinitepay.io"))
+		# Apenas HTTPS é aceito
+		self.assertFalse(_is_safe_receipt_url("http://recibo.infinitepay.io/abc"))
+		self.assertFalse(_is_safe_receipt_url("ftp://recibo.infinitepay.io/abc"))
+		# Valores vazios / None
+		self.assertFalse(_is_safe_receipt_url(""))
+		self.assertFalse(_is_safe_receipt_url(None))
+
+	def test_mask_email(self):
+		self.assertEqual(_mask_email("caio@example.com"), "c***@example.com")
+		self.assertEqual(_mask_email("a@b.com"), "a***@b.com")
+		# Sem domínio com ponto → não vaza
+		self.assertEqual(_mask_email("a@invalid"), "")
+		self.assertEqual(_mask_email(""), "")
+		self.assertEqual(_mask_email(None), "")
+
+
+class TestGetStatusEndpoint(FrappeTestCase):
+	def setUp(self):
+		# Limpa side-effects entre testes
+		self.original_response = dict(frappe.local.response)
+		self.addCleanup(self._restore_response)
+
+	def _restore_response(self):
+		frappe.local.response.clear()
+		frappe.local.response.update(self.original_response)
+
+	def test_get_status_sem_token_retorna_404(self):
+		resultado = get_status(c="CF-2026-00001", t="invalido")
+		self.assertEqual(frappe.local.response.get("http_status_code"), 404)
+		self.assertEqual(resultado["status"], "Indisponivel")
+		self.assertIsNone(resultado["atualizado_em"])
+
+	def test_get_status_para_nome_invalido_retorna_404(self):
+		resultado = get_status(c="../../etc/passwd", t="")
+		self.assertEqual(frappe.local.response.get("http_status_code"), 404)
+		self.assertEqual(resultado["status"], "Indisponivel")
+
+	def test_get_status_para_convite_inexistente_retorna_404(self):
+		nome = "CF-2099-99999"
+		token = _build_token(nome)
+		resultado = get_status(c=nome, t=token)
+		self.assertEqual(frappe.local.response.get("http_status_code"), 404)
+		self.assertEqual(resultado["status"], "Indisponivel")
+
+	def test_get_status_so_devolve_status_e_timestamp(self):
+		# Mocka frappe.db.get_value para simular um convite real sem precisar de fixtures
+		nome = "CF-2026-12345"
+		token = _build_token(nome)
+
+		def _fake_get_value(doctype, name, fields, as_dict=False):
+			if doctype == "Convite Festa" and name == nome:
+				return frappe._dict({"cobranca_infinitepay": "CI-001", "modified": None})
+			if doctype == "Cobranca Infinitepay" and name == "CI-001":
+				return frappe._dict({"status": "Pago", "modified": None})
+			return None
+
+		with patch("frappe.db.get_value", side_effect=_fake_get_value):
+			resultado = get_status(c=nome, t=token)
+
+		self.assertEqual(set(resultado.keys()), {"status", "atualizado_em"})
+		self.assertEqual(resultado["status"], "Pago")

--- a/gris/api/financeiro/test_infinitepay_webhook.py
+++ b/gris/api/financeiro/test_infinitepay_webhook.py
@@ -49,6 +49,8 @@ def _convite(festa_name: str, opcao_name: str, quantidade: int = 2):
 
 def _fake_request(payload: dict):
 	class _Req:
+		host = "dev.gris"
+
 		def get_data(self, *, as_text: bool = False):
 			return json.dumps(payload)
 
@@ -133,12 +135,19 @@ class TestInfinitepayWebhook(FrappeTestCase):
 		self.assertEqual(int(opcao.quantidade_vendida), 3)
 
 		self.mock_enqueue.assert_called()
-		args, kwargs = self.mock_enqueue.call_args
-		self.assertEqual(
-			args[0] if args else kwargs.get("method"),
+		chamadas_convite = {
+			(call.args[0] if call.args else call.kwargs.get("method")): call.kwargs
+			for call in self.mock_enqueue.call_args_list
+			if call.kwargs.get("convite_name") == convite.name
+		}
+		self.assertIn(
 			"gris.festas.doctype.convite_festa.convite_festa.enviar_qr_codes",
+			chamadas_convite,
 		)
-		self.assertEqual(kwargs.get("convite_name"), convite.name)
+		self.assertIn(
+			"gris.festas.doctype.convite_festa.convite_festa.enviar_whatsapp_confirmacao_convite",
+			chamadas_convite,
+		)
 
 	def test_webhook_para_cobranca_inexistente_retorna_400(self):
 		_fake_request({"order_nsu": "CF-INEXISTENTE"})

--- a/gris/festas/doctype/convidado_convite_festa/convidado_convite_festa.json
+++ b/gris/festas/doctype/convidado_convite_festa/convidado_convite_festa.json
@@ -10,7 +10,8 @@
   "qr_code_payload",
   "qr_code",
   "status_envio",
-  "descricao_erro_envio"
+  "descricao_erro_envio",
+  "whatsapp_notificado_em"
  ],
  "fields": [
   {
@@ -59,6 +60,14 @@
    "fieldname": "descricao_erro_envio",
    "fieldtype": "Small Text",
    "label": "Descrição do Erro de Envio",
+   "read_only": 1
+  },
+  {
+   "fieldname": "whatsapp_notificado_em",
+   "fieldtype": "Datetime",
+   "hidden": 1,
+   "label": "WhatsApp Notificado em",
+   "no_copy": 1,
    "read_only": 1
   }
  ],

--- a/gris/festas/doctype/convite_festa/convite_festa.json
+++ b/gris/festas/doctype/convite_festa/convite_festa.json
@@ -20,7 +20,8 @@
   "cobranca_infinitepay",
   "secao_controle",
   "pagador_recebe_qr_codes",
-  "convidados"
+  "convidados",
+  "whatsapp_notificado_em"
  ],
  "fields": [
   {
@@ -122,6 +123,14 @@
    "fieldtype": "Table",
    "label": "Convidados",
    "options": "Convidado Convite Festa"
+  },
+  {
+   "fieldname": "whatsapp_notificado_em",
+   "fieldtype": "Datetime",
+   "hidden": 1,
+   "label": "WhatsApp Notificado em",
+   "no_copy": 1,
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,

--- a/gris/festas/doctype/convite_festa/convite_festa.py
+++ b/gris/festas/doctype/convite_festa/convite_festa.py
@@ -183,6 +183,8 @@ class ConviteFesta(Document):
 				convidado.status_envio = STATUS_ENVIO_PENDENTE
 
 	def _criar_cobranca_infinitepay(self):
+		from gris.api.festas.convite_confirmado import _build_redirect_url
+
 		cobranca = frappe.get_doc(
 			{
 				"doctype": "Cobranca Infinitepay",
@@ -190,6 +192,7 @@ class ConviteFesta(Document):
 				"customer_name": self.nome_pagador,
 				"customer_email": self.email_pagador,
 				"customer_phone": self.telefone_pagador,
+				"redirect_url": _build_redirect_url(self.name),
 				"itens": [
 					{
 						"descricao": it.descricao,
@@ -231,6 +234,12 @@ def on_cobranca_atualizada(doc, method=None):
 		frappe.enqueue(
 			"gris.festas.doctype.convite_festa.convite_festa.enviar_qr_codes",
 			queue="long",
+			enqueue_after_commit=True,
+			convite_name=convite_name,
+		)
+		frappe.enqueue(
+			"gris.festas.doctype.convite_festa.convite_festa.enviar_whatsapp_confirmacao_convite",
+			queue="short",
 			enqueue_after_commit=True,
 			convite_name=convite_name,
 		)
@@ -509,6 +518,109 @@ def _mensagem_whatsapp_erro(
 		f"[GRIS] Falha ao enviar QR codes do Convite Festa {convite_name} "
 		f"({festa_nome}).\nConvidados em erro:\n{linhas}"
 	)
+
+
+# ---------- WhatsApp: confirmação de pagamento ----------
+
+
+def enviar_whatsapp_confirmacao_convite(convite_name: str) -> None:
+	"""Job de background: notifica via WhatsApp que o pagamento foi confirmado.
+
+	- Idempotente: usa `whatsapp_notificado_em` no Convite Festa (e por linha em
+	  Convidado Convite Festa) para evitar reenvios quando o webhook é reentrante.
+	- Disparada apenas pelo handler `on_cobranca_atualizada` (sistema), nunca por
+	  ações do usuário/visita de página.
+	- Falhas em mensagens individuais não interrompem o fluxo: são logadas e
+	  marcadas no respectivo registro.
+	"""
+	from frappe.utils import now
+
+	from gris.api.festas.convite_confirmado import (
+		_build_redirect_url,
+		_mask_email,
+	)
+	from gris.utils.whatsapp import enviar_texto
+
+	doc = frappe.get_doc("Convite Festa", convite_name)
+	if doc.status_pagamento != STATUS_PAGAMENTO_PAGO:
+		return
+
+	festa_nome = frappe.db.get_value("Festa", doc.festa, "nome_festa") or doc.festa
+	primeiro_nome_pagador = _primeiro_nome(doc.nome_pagador)
+	qtd_convites = sum(int(it.quantidade or 0) for it in doc.itens if it.eh_convite)
+	link_assinado = _build_redirect_url(doc.name)
+	pagador_recebe_tudo = bool(doc.pagador_recebe_qr_codes)
+
+	# 1) Mensagem para o pagador (uma única vez)
+	if not doc.whatsapp_notificado_em and doc.telefone_pagador:
+		if pagador_recebe_tudo:
+			mensagem_pagador = (
+				f"Olá, {primeiro_nome_pagador}!\n"
+				f"Recebemos o pagamento da sua compra de {qtd_convites} convite(s) para {festa_nome}.\n"
+				f"Em breve você receberá os convites no e-mail {_mask_email(doc.email_pagador)}.\n"
+				"Apresente-os na entrada da festa.\n"
+				f"Confirmação e recibo: {link_assinado}"
+			)
+		else:
+			mensagem_pagador = (
+				f"Olá, {primeiro_nome_pagador}!\n"
+				f"Recebemos o pagamento da sua compra de {qtd_convites} convite(s) para {festa_nome}.\n"
+				"Cada convidado receberá seu convite no e-mail informado.\n"
+				f"Confirmação e recibo: {link_assinado}"
+			)
+		try:
+			enviar_texto(doc.telefone_pagador, mensagem_pagador)
+		except Exception:
+			frappe.log_error(
+				message=frappe.get_traceback(),
+				title=f"Falha ao notificar pagador via WhatsApp ({doc.name})",
+			)
+
+	frappe.db.set_value(
+		"Convite Festa",
+		doc.name,
+		"whatsapp_notificado_em",
+		now(),
+		update_modified=False,
+	)
+
+	# 2) Mensagens individuais por convidado (apenas se cada um recebe o próprio)
+	if pagador_recebe_tudo:
+		return
+
+	for convidado in doc.convidados or []:
+		if convidado.whatsapp_notificado_em:
+			continue
+		telefone = (convidado.telefone or "").strip()
+		if not telefone:
+			continue
+		mensagem_convidado = (
+			f"Olá, {_primeiro_nome(convidado.nome)}!\n"
+			f"Um convite para {festa_nome} foi comprado em seu nome.\n"
+			f"Em breve você receberá o convite no e-mail {_mask_email(convidado.email)}.\n"
+			"Apresente esse convite na entrada da festa."
+		)
+		try:
+			enviar_texto(telefone, mensagem_convidado)
+		except Exception:
+			frappe.log_error(
+				message=frappe.get_traceback(),
+				title=f"Falha ao notificar convidado via WhatsApp ({doc.name}/{convidado.name})",
+			)
+			continue
+		frappe.db.set_value(
+			"Convidado Convite Festa",
+			convidado.name,
+			"whatsapp_notificado_em",
+			now(),
+			update_modified=False,
+		)
+
+
+def _primeiro_nome(nome: str | None) -> str:
+	if not nome:
+		return ""
+	return (nome.strip().split(" ", 1)[0] or "").strip()
 
 
 @frappe.whitelist()

--- a/gris/festas/doctype/convite_festa/test_convite_whatsapp.py
+++ b/gris/festas/doctype/convite_festa/test_convite_whatsapp.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2026, Grupo Escoteiro Professora Inah de Mello - 47/SP and Contributors
+# See license.txt
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from gris.festas.doctype.compra_festa.test_compra_festa import _nova_festa
+from gris.festas.doctype.convite_festa.convite_festa import (
+	enviar_whatsapp_confirmacao_convite,
+)
+
+
+def _opcao(festa_name: str):
+	return frappe.get_doc(
+		{
+			"doctype": "Opcao Convite Festa",
+			"festa": festa_name,
+			"nome_convite": "Inteira",
+			"valor": 50,
+		}
+	).insert(ignore_permissions=True)
+
+
+def _convite(festa_name: str, opcao_name: str, *, pagador_recebe: bool, convidados):
+	return frappe.get_doc(
+		{
+			"doctype": "Convite Festa",
+			"festa": festa_name,
+			"nome_pagador": "Caio Bernardo",
+			"telefone_pagador": "11988887777",
+			"email_pagador": "caio@example.com",
+			"pagador_recebe_qr_codes": 1 if pagador_recebe else 0,
+			"itens": [
+				{
+					"eh_convite": 1,
+					"opcao_convite": opcao_name,
+					"descricao": "Inteira",
+					"quantidade": len(convidados),
+					"valor": 50,
+				}
+			],
+			"convidados": convidados,
+		}
+	).insert(ignore_permissions=True)
+
+
+def _marcar_cobranca_paga(cobranca_name: str) -> None:
+	frappe.db.set_value("Cobranca Infinitepay", cobranca_name, "status", "Pago")
+
+
+class TestConfirmacaoWhatsApp(FrappeTestCase):
+	def setUp(self):
+		link_patcher = patch(
+			"gris.financeiro.doctype.cobranca_infinitepay.cobranca_infinitepay.CobrancaInfinitepay._criar_link_pagamento",
+			lambda self: None,
+		)
+		link_patcher.start()
+		self.addCleanup(link_patcher.stop)
+
+		whatsapp_patcher = patch("gris.utils.whatsapp.enviar_texto")
+		self.mock_whatsapp = whatsapp_patcher.start()
+		self.addCleanup(whatsapp_patcher.stop)
+
+	def test_so_envia_quando_cobranca_esta_paga(self):
+		festa = _nova_festa()
+		opcao = _opcao(festa.name)
+		convite = _convite(
+			festa.name,
+			opcao.name,
+			pagador_recebe=True,
+			convidados=[{"nome": "Caio Bernardo", "email": "caio@example.com"}],
+		)
+		# Cobrança ainda Pendente
+		enviar_whatsapp_confirmacao_convite(convite.name)
+		self.mock_whatsapp.assert_not_called()
+
+	def test_pagador_recebe_tudo_envia_apenas_para_pagador(self):
+		festa = _nova_festa()
+		opcao = _opcao(festa.name)
+		convite = _convite(
+			festa.name,
+			opcao.name,
+			pagador_recebe=True,
+			convidados=[
+				{"nome": "Caio Bernardo", "email": "caio@example.com"},
+				{"nome": "Caio Bernardo", "email": "caio@example.com"},
+			],
+		)
+		_marcar_cobranca_paga(convite.cobranca_infinitepay)
+
+		enviar_whatsapp_confirmacao_convite(convite.name)
+
+		self.assertEqual(self.mock_whatsapp.call_count, 1)
+		numero, mensagem = self.mock_whatsapp.call_args.args
+		self.assertEqual(numero, "11988887777")
+		self.assertIn("Caio", mensagem)
+		# Não deve vazar e-mail completo
+		self.assertNotIn("caio@example.com", mensagem)
+		self.assertIn("c***@example.com", mensagem)
+		# Link assinado presente
+		self.assertIn("/festas/convite_confirmado?c=", mensagem)
+
+		convite.reload()
+		self.assertTrue(convite.whatsapp_notificado_em)
+
+	def test_individual_envia_uma_para_cada_convidado_com_telefone(self):
+		festa = _nova_festa()
+		opcao = _opcao(festa.name)
+		convite = _convite(
+			festa.name,
+			opcao.name,
+			pagador_recebe=False,
+			convidados=[
+				{"nome": "Alice", "email": "alice@example.com", "telefone": "11911111111"},
+				{"nome": "Bob", "email": "bob@example.com", "telefone": "11922222222"},
+				{"nome": "Carol", "email": "carol@example.com"},  # sem telefone
+			],
+		)
+		_marcar_cobranca_paga(convite.cobranca_infinitepay)
+
+		enviar_whatsapp_confirmacao_convite(convite.name)
+
+		# 1 pagador + 2 convidados com telefone = 3 chamadas
+		self.assertEqual(self.mock_whatsapp.call_count, 3)
+		numeros = [c.args[0] for c in self.mock_whatsapp.call_args_list]
+		self.assertIn("11988887777", numeros)
+		self.assertIn("11911111111", numeros)
+		self.assertIn("11922222222", numeros)
+
+		# Convidados não recebem o link assinado
+		mensagens_convidados = [
+			c.args[1] for c in self.mock_whatsapp.call_args_list if c.args[0] != "11988887777"
+		]
+		for msg in mensagens_convidados:
+			self.assertNotIn("/festas/convite_confirmado?c=", msg)
+			self.assertNotIn("11988887777", msg)
+			self.assertNotIn("caio@example.com", msg)
+
+	def test_idempotencia_nao_reenvia(self):
+		festa = _nova_festa()
+		opcao = _opcao(festa.name)
+		convite = _convite(
+			festa.name,
+			opcao.name,
+			pagador_recebe=False,
+			convidados=[
+				{"nome": "Alice", "email": "alice@example.com", "telefone": "11911111111"},
+			],
+		)
+		_marcar_cobranca_paga(convite.cobranca_infinitepay)
+
+		enviar_whatsapp_confirmacao_convite(convite.name)
+		self.assertEqual(self.mock_whatsapp.call_count, 2)
+
+		# Segunda execução não deve disparar nada (idempotência via timestamp)
+		enviar_whatsapp_confirmacao_convite(convite.name)
+		self.assertEqual(self.mock_whatsapp.call_count, 2)
+
+	def test_falha_em_um_convidado_nao_interrompe_os_demais(self):
+		festa = _nova_festa()
+		opcao = _opcao(festa.name)
+		convite = _convite(
+			festa.name,
+			opcao.name,
+			pagador_recebe=False,
+			convidados=[
+				{"nome": "Alice", "email": "alice@example.com", "telefone": "11911111111"},
+				{"nome": "Bob", "email": "bob@example.com", "telefone": "11922222222"},
+			],
+		)
+		_marcar_cobranca_paga(convite.cobranca_infinitepay)
+
+		chamadas = {"n": 0}
+
+		def side_effect(numero, mensagem, **kwargs):
+			chamadas["n"] += 1
+			if numero == "11911111111":
+				raise RuntimeError("Network down")
+			return None
+
+		self.mock_whatsapp.side_effect = side_effect
+
+		enviar_whatsapp_confirmacao_convite(convite.name)
+
+		# pagador + 2 convidados (1 com erro)
+		self.assertEqual(self.mock_whatsapp.call_count, 3)

--- a/gris/festas/print_format/convite_festa_qr/convite_festa_qr.html
+++ b/gris/festas/print_format/convite_festa_qr/convite_festa_qr.html
@@ -4,61 +4,89 @@
 		<meta charset="utf-8" />
 		<title>Convite — {{ festa.nome_festa }}</title>
 		<style>
-			@page { size: A5; margin: 16mm; }
+			@page { size: A5; margin: 14mm; }
 			body {
 				font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-				color: #1a2733;
+				color: #0f1b26;
+				background: #ffffff;
 				margin: 0;
+				padding: 0;
+				text-align: center;
 			}
-			.wrapper {
-				border: 1px solid #d8e0e9;
-				border-radius: 12px;
-				padding: 28px 32px;
-			}
-			.brand {
-				color: #0d4d91;
-				font-size: 11px;
-				letter-spacing: 2px;
-				text-transform: uppercase;
-				margin-bottom: 8px;
-			}
+			.page { width: 100%; }
+			.logo { margin: 0 auto 18px; }
+			.logo img { max-height: 110px; max-width: 220px; }
 			h1 {
-				margin: 0 0 4px;
+				margin: 0 0 6px;
 				font-size: 26px;
 				color: #0d4d91;
+				font-weight: 700;
+				letter-spacing: -0.01em;
 			}
 			.subtitulo {
-				color: #5a6877;
-				font-size: 14px;
-				margin-bottom: 24px;
+				color: #64748b;
+				font-size: 13px;
+				margin-bottom: 28px;
 			}
-			.dados {
-				margin: 24px 0;
-				font-size: 14px;
-				line-height: 1.55;
+			.dados { margin: 0 auto 24px; }
+			.dado { margin-bottom: 14px; }
+			.dado .rotulo {
+				font-size: 10px;
+				letter-spacing: 1.6px;
+				text-transform: uppercase;
+				color: #64748b;
+				margin-bottom: 2px;
 			}
-			.dados strong { color: #0d4d91; }
-			.qr {
-				text-align: center;
-				margin: 24px 0;
+			.dado .valor {
+				font-size: 15px;
+				color: #0f1b26;
+				font-weight: 600;
 			}
-			.qr img {
-				width: 220px;
-				height: 220px;
+			.qr-card {
+				display: inline-block;
+				background: #ffffff;
+				border: 1px solid #e2e8f0;
+				border-radius: 12px;
+				padding: 16px;
+				margin: 8px auto 14px;
+				box-shadow: 0 6px 18px rgba(15, 27, 38, 0.08),
+					0 2px 4px rgba(15, 27, 38, 0.05);
 			}
-			.footer {
-				border-top: 1px solid #d8e0e9;
-				margin-top: 24px;
-				padding-top: 12px;
+			.qr-card img { display: block; width: 200px; height: 200px; }
+			.qr-codigo {
+				margin: 10px auto 18px;
+				font-family: "Menlo", "Consolas", "Courier New", monospace;
 				font-size: 11px;
-				color: #93a1b1;
-				text-align: center;
+				color: #475569;
+				letter-spacing: 0.5px;
+				word-break: break-all;
 			}
+			.instrucao {
+				color: #64748b;
+				font-size: 12px;
+				margin-bottom: 22px;
+			}
+			hr {
+				border: none;
+				border-top: 1px solid #e2e8f0;
+				max-width: 60%;
+				margin: 18px auto;
+			}
+			.assinatura {
+				color: #64748b;
+				font-size: 11px;
+			}
+			.assinatura .coracao { color: #d6336c; }
 		</style>
 	</head>
 	<body>
-		<div class="wrapper">
-			<div class="brand">GRIS · Convite de Entrada</div>
+		<div class="page">
+			{% if uel_logo_b64 %}
+			<div class="logo">
+				<img src="data:image/png;base64,{{ uel_logo_b64 }}" alt="Logo" />
+			</div>
+			{% endif %}
+
 			<h1>{{ festa.nome_festa }}</h1>
 			<div class="subtitulo">
 				{{ frappe.format_value(festa.data, {"fieldtype": "Date"}) }}
@@ -69,17 +97,33 @@
 			</div>
 
 			<div class="dados">
-				<div><strong>Convidado:</strong> {{ convidado.nome }}</div>
-				<div><strong>Tipo de convite:</strong> {{ tipo_convite }}</div>
-				<div><strong>Pedido:</strong> {{ convite.name }}</div>
+				<div class="dado">
+					<div class="rotulo">Convidado</div>
+					<div class="valor">{{ convidado.nome }}</div>
+				</div>
+				<div class="dado">
+					<div class="rotulo">Tipo de convite</div>
+					<div class="valor">{{ tipo_convite }}</div>
+				</div>
+				<div class="dado">
+					<div class="rotulo">Pedido</div>
+					<div class="valor">{{ convite.name }}</div>
+				</div>
 			</div>
 
-			<div class="qr">
+			<div class="qr-card">
 				<img src="data:image/png;base64,{{ qr_png_b64 }}" alt="QR code do convite" />
 			</div>
+			<div class="qr-codigo">{{ convidado.qr_code_payload }}</div>
+			<div class="instrucao">
+				Apresente este QR code na entrada da festa.
+			</div>
 
-			<div class="footer">
-				Apresente este QR code na portaria para liberação da entrada.
+			<hr />
+
+			<div class="assinatura">
+				Feito com <span class="coracao">&#10084;</span> por
+				{% if uel_tipo %}{{ uel_tipo }} {% endif %}{{ uel_nome }}
 			</div>
 		</div>
 	</body>

--- a/gris/festas/utils/convite_qr.py
+++ b/gris/festas/utils/convite_qr.py
@@ -123,12 +123,21 @@ def _sobrepor_logo(qr_img: Image.Image, logo: Image.Image) -> Image.Image:
 def gerar_pdf_convite(convite, convidado, *, item_convite=None) -> bytes:
 	"""Renderiza o PDF de um convite individual.
 
-	Conteúdo: nome da festa, data, horário, nome do convidado, tipo de convite
-	e o QR code. O template fica em `festas/print_format/convite_festa_qr/`.
+	Conteúdo: logo da UEL, nome da festa, data, horário, dados do convidado e
+	QR code em card com sombra. O template fica em
+	`festas/print_format/convite_festa_qr/`.
 	"""
 	festa = frappe.get_doc("Festa", convite.festa)
 	tipo_convite = _descobrir_tipo_convite(convite, item_convite)
 	png = gerar_png(convidado.qr_code_payload)
+	uel = frappe.get_cached_doc("Definicao da UEL")
+	logo_img = _carregar_logo()
+	uel_logo_b64 = ""
+	if logo_img is not None:
+		buf = io.BytesIO()
+		logo_img.save(buf, format="PNG")
+		uel_logo_b64 = base64.b64encode(buf.getvalue()).decode()
+
 	template_path = os.path.join(
 		frappe.get_app_path("gris"),
 		"festas",
@@ -147,6 +156,9 @@ def gerar_pdf_convite(convite, convidado, *, item_convite=None) -> bytes:
 			"convidado": convidado,
 			"tipo_convite": tipo_convite,
 			"qr_png_b64": base64.b64encode(png).decode(),
+			"uel_tipo": uel.get("tipo_uel") or "",
+			"uel_nome": uel.get("nome_da_uel") or "",
+			"uel_logo_b64": uel_logo_b64,
 		},
 	)
 	return get_pdf(html)

--- a/gris/www/festas/convite_confirmado.css
+++ b/gris/www/festas/convite_confirmado.css
@@ -1,0 +1,191 @@
+.cc-page {
+	min-height: 100vh;
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	padding: clamp(1.5rem, 4vw, 3rem) 1rem 2rem;
+	gap: clamp(1.25rem, 3vw, 2rem);
+	background: var(--background);
+	color: var(--foreground);
+}
+
+.cc-hero {
+	display: flex;
+	justify-content: center;
+	width: 100%;
+}
+
+.cc-hero__logo {
+	max-height: 80px;
+	max-width: 200px;
+	object-fit: contain;
+}
+
+.cc-main {
+	width: 100%;
+	max-width: 640px;
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.cc-card {
+	display: flex;
+	flex-direction: column;
+	gap: 1.25rem;
+}
+
+.cc-card section {
+	display: flex;
+	flex-direction: column;
+	gap: 1.25rem;
+}
+
+.cc-status {
+	display: flex;
+	align-items: flex-start;
+	gap: 1rem;
+}
+
+.cc-status__icone {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 3rem;
+	height: 3rem;
+	border-radius: 999px;
+	flex-shrink: 0;
+}
+
+.cc-status__icone--sucesso {
+	background: color-mix(in oklab, var(--success) 14%, transparent);
+	color: var(--success);
+}
+
+.cc-status__icone--pendente {
+	background: color-mix(in oklab, var(--info, var(--primary)) 14%, transparent);
+	color: var(--info, var(--primary));
+}
+
+.cc-status__icone--pendente .ds-lucide {
+	animation: cc-spin 1.4s linear infinite;
+}
+
+.cc-status__icone--falha {
+	background: color-mix(in oklab, var(--destructive) 14%, transparent);
+	color: var(--destructive);
+}
+
+@keyframes cc-spin {
+	from { transform: rotate(0deg); }
+	to { transform: rotate(360deg); }
+}
+
+.cc-status__titulo {
+	margin: 0 0 0.25rem;
+	font-size: 1.25rem;
+	font-weight: 600;
+	line-height: 1.25;
+	color: var(--foreground);
+}
+
+.cc-status__subtitulo {
+	margin: 0;
+	color: var(--muted-foreground);
+	font-size: 0.95rem;
+}
+
+.cc-festa__nome {
+	margin: 0;
+	font-size: 1.5rem;
+	font-weight: 700;
+	line-height: 1.2;
+	color: var(--foreground);
+}
+
+.cc-festa__dados {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 0.5rem;
+	margin: 0;
+	padding: 0;
+}
+
+.cc-festa__linha {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+	padding: 0.75rem 1rem;
+	border-radius: var(--radius);
+	background: var(--muted);
+}
+
+.cc-festa__linha dt {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	color: var(--muted-foreground);
+	font-weight: 500;
+	margin: 0;
+}
+
+.cc-festa__linha dd {
+	margin: 0;
+	font-weight: 600;
+	color: var(--foreground);
+}
+
+.cc-orientacoes {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+}
+
+.cc-actions {
+	display: flex;
+	gap: 0.75rem;
+	flex-wrap: wrap;
+}
+
+.cc-receipt {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+}
+
+.cc-pendente__ajuda {
+	color: var(--muted-foreground);
+	margin: 0;
+	font-size: 0.95rem;
+	line-height: 1.5;
+}
+
+.cc-footer {
+	margin-top: auto;
+	width: 100%;
+	max-width: 640px;
+	padding: 1.5rem 0 0.5rem;
+	border-top: 1px solid var(--border);
+	text-align: center;
+	color: var(--muted-foreground);
+}
+
+.cc-footer p {
+	margin: 0;
+	font-size: 0.9rem;
+}
+
+.cc-footer__sub {
+	margin-top: 0.25rem !important;
+	font-size: 0.8rem;
+}
+
+@media (max-width: 480px) {
+	.cc-festa__linha {
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 0.25rem;
+	}
+}

--- a/gris/www/festas/convite_confirmado.html
+++ b/gris/www/festas/convite_confirmado.html
@@ -1,0 +1,145 @@
+{% extends "gris/templates/portal_clean.html" %}
+{% from "public/design_system/components/composed/basecoat-composed.html.jinja" import card, button, alert %}
+{% from "public/design_system/components/composed/lucide.html.jinja" import lucide_icon %}
+
+{% block title %}Pagamento confirmado{% endblock %}
+
+{% block head_include %}
+{{ super() }}
+<link rel="stylesheet" href="/festas/convite_confirmado.css" />
+{% endblock %}
+
+{% block page_content %}
+<div class="cc-page" data-estado="{{ estado }}" data-convite="{{ convite_name }}" data-token="{{ convite_token }}">
+
+	<section class="cc-hero">
+		{% if portal_logo %}
+		<img class="cc-hero__logo" src="{{ portal_logo }}" alt="Logo da Unidade Escoteira Local" />
+		{% else %}
+		<img class="cc-hero__logo" src="/assets/gris/images/gris-character/gris-logo.png" alt="GRIS" onerror="this.style.display='none'" />
+		{% endif %}
+	</section>
+
+	<main class="cc-main">
+
+		{% if estado == "pago" %}
+		{% call card(attrs={"class": "cc-card cc-card--pago"}) %}
+			<div class="cc-status">
+				<span class="cc-status__icone cc-status__icone--sucesso">{{ lucide_icon("circle-check", "lg") }}</span>
+				<div>
+					<h1 class="cc-status__titulo">Pagamento confirmado</h1>
+					<p class="cc-status__subtitulo">Seu pedido foi processado com sucesso.</p>
+				</div>
+			</div>
+
+			<h2 class="cc-festa__nome">{{ festa.nome }}</h2>
+
+			<dl class="cc-festa__dados">
+				{% if festa.data %}
+				<div class="cc-festa__linha">
+					<dt>{{ lucide_icon("calendar-check", "sm") }} <span>Data</span></dt>
+					<dd>{{ festa.data }}</dd>
+				</div>
+				{% endif %}
+				{% if festa.horario_inicio or festa.horario_termino %}
+				<div class="cc-festa__linha">
+					<dt>{{ lucide_icon("clock", "sm") }} <span>Horário</span></dt>
+					<dd>
+						{% if festa.horario_inicio %}{{ festa.horario_inicio }}{% endif %}
+						{% if festa.horario_inicio and festa.horario_termino %} — {% endif %}
+						{% if festa.horario_termino %}{{ festa.horario_termino }}{% endif %}
+					</dd>
+				</div>
+				{% endif %}
+			</dl>
+
+			<div class="cc-orientacoes">
+				{% if pagador_recebe_qr_codes %}
+				{% set descricao_html %}
+					Todos os convites foram enviados para <strong>{{ email_pagador_mascarado }}</strong>.
+					Apresente-os impressos ou no celular na entrada da festa.
+				{% endset %}
+				{{ alert(
+					title="Seus convites estão a caminho",
+					description=descricao_html,
+					icon=lucide_icon("mail-check", "md"),
+					variant="success"
+				) }}
+				{% else %}
+				{% set descricao_html %}
+					Cada convidado receberá seu convite no e-mail informado durante a compra.
+					Cada um deverá apresentar o próprio convite na entrada da festa.
+				{% endset %}
+				{{ alert(
+					title="Convites enviados individualmente",
+					description=descricao_html,
+					icon=lucide_icon("ticket-check", "md"),
+					variant="success"
+				) }}
+				{% endif %}
+			</div>
+
+			{% if receipt_url %}
+			<div class="cc-actions">
+				<a class="btn-primary cc-receipt"
+				   href="{{ receipt_url }}"
+				   target="_blank"
+				   rel="noopener noreferrer">
+					{{ lucide_icon("receipt", "sm") }} Abrir recibo
+				</a>
+			</div>
+			{% endif %}
+		{% endcall %}
+
+		{% elif estado == "pendente" %}
+		{% call card(attrs={"class": "cc-card cc-card--pendente"}) %}
+			<div class="cc-status">
+				<span class="cc-status__icone cc-status__icone--pendente">{{ lucide_icon("loader", "lg") }}</span>
+				<div>
+					<h1 class="cc-status__titulo">Pagamento sendo processado</h1>
+					<p class="cc-status__subtitulo">
+						Estamos confirmando seu pagamento com a operadora.
+						Esta página vai atualizar automaticamente em alguns segundos.
+					</p>
+				</div>
+			</div>
+			<p class="cc-pendente__ajuda" id="cc-pendente-ajuda">
+				Se demorar mais que alguns minutos, você pode fechar esta página com segurança:
+				assim que o pagamento for confirmado, enviaremos os convites para o e-mail informado
+				durante a compra.
+			</p>
+		{% endcall %}
+
+		{% else %}
+		{% call card(attrs={"class": "cc-card cc-card--falha"}) %}
+			<div class="cc-status">
+				<span class="cc-status__icone cc-status__icone--falha">{{ lucide_icon("triangle-alert", "lg") }}</span>
+				<div>
+					<h1 class="cc-status__titulo">Não conseguimos confirmar o pagamento</h1>
+					<p class="cc-status__subtitulo">
+						A operadora indicou que o pagamento não foi concluído.
+						Se você acredita que pagou, aguarde alguns minutos e recarregue esta página.
+					</p>
+				</div>
+			</div>
+			<div class="cc-actions">
+				<a class="btn-outline" href="/festas/venda_convite">Voltar para a compra</a>
+			</div>
+		{% endcall %}
+		{% endif %}
+
+	</main>
+
+	{% if uel.nome_da_uel %}
+	<footer class="cc-footer">
+		<p>
+			{% if uel.tipo_uel %}{{ uel.tipo_uel }} {% endif %}{{ uel.nome_da_uel }}{% if uel.numeral %} {{ uel.numeral }}{% endif %}
+		</p>
+		{% if uel.regiao %}<p class="cc-footer__sub">{{ uel.regiao }}</p>{% endif %}
+	</footer>
+	{% endif %}
+
+</div>
+
+<script src="/festas/convite_confirmado.js" defer></script>
+{% endblock %}

--- a/gris/www/festas/convite_confirmado.js
+++ b/gris/www/festas/convite_confirmado.js
@@ -1,0 +1,87 @@
+(function () {
+	"use strict";
+
+	const POLL_INTERVAL_MS = 5000;
+	const MAX_ATTEMPTS = 60; // ~5 min total
+
+	const root = document.querySelector(".cc-page");
+	if (!root) return;
+	if (root.dataset.estado !== "pendente") return;
+
+	const convite = root.dataset.convite || "";
+	const token = root.dataset.token || "";
+	if (!convite || !token) return;
+
+	let attempts = 0;
+	let timer = null;
+	let stopped = false;
+
+	function stop() {
+		stopped = true;
+		if (timer) {
+			clearTimeout(timer);
+			timer = null;
+		}
+	}
+
+	function scheduleNext() {
+		if (stopped || attempts >= MAX_ATTEMPTS) return;
+		timer = setTimeout(poll, POLL_INTERVAL_MS);
+	}
+
+	async function poll() {
+		if (stopped) return;
+		attempts += 1;
+		try {
+			const url =
+				"/api/method/gris.api.festas.convite_confirmado.get_status" +
+				"?c=" + encodeURIComponent(convite) +
+				"&t=" + encodeURIComponent(token);
+			const response = await fetch(url, {
+				method: "GET",
+				headers: { "X-Requested-With": "XMLHttpRequest" },
+				credentials: "same-origin",
+			});
+			if (response.status === 404) {
+				stop();
+				return;
+			}
+			if (response.status === 429) {
+				scheduleNext();
+				return;
+			}
+			if (!response.ok) {
+				scheduleNext();
+				return;
+			}
+			const payload = await response.json();
+			const status = (payload && payload.message && payload.message.status) || "";
+			if (status === "Pago") {
+				stop();
+				window.location.reload();
+				return;
+			}
+			if (status === "Erro" || status === "Cancelado" || status === "Estornado" || status === "Expirado") {
+				stop();
+				window.location.reload();
+				return;
+			}
+			scheduleNext();
+		} catch (_err) {
+			scheduleNext();
+		}
+	}
+
+	document.addEventListener("visibilitychange", function () {
+		if (document.hidden) {
+			if (timer) {
+				clearTimeout(timer);
+				timer = null;
+			}
+		} else if (!stopped && attempts < MAX_ATTEMPTS) {
+			scheduleNext();
+		}
+	});
+
+	scheduleNext();
+})();

--- a/gris/www/festas/convite_confirmado.py
+++ b/gris/www/festas/convite_confirmado.py
@@ -1,0 +1,134 @@
+"""Página pública /festas/convite_confirmado.
+
+Renderizada após a Infinitepay redirecionar o comprador de volta ao GRIS.
+O acesso é protegido por um token HMAC (gerado em
+`gris.api.festas.convite_confirmado._build_token`). Sem token válido, devolve 404.
+
+A página apresenta apenas dados não sensíveis (nome da festa, data, horário,
+e-mails mascarados, link para o recibo da Infinitepay). Nenhum side-effect
+(envio de WhatsApp / e-mail) acontece aqui — esses só são disparados pelo
+webhook autenticado da Infinitepay.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta
+
+import frappe
+
+from gris.api.festas.convite_confirmado import (
+	_is_safe_receipt_url,
+	_mask_email,
+	_validate_token,
+)
+from gris.api.portal_cache_utils import get_uel_cached
+
+no_cache = 1
+
+STATUS_PAGO = "Pago"
+STATUS_FALHA = {"Erro", "Cancelado", "Estornado", "Expirado"}
+
+
+def get_context(context):
+	context.title = "Pagamento confirmado"
+	context.show_sidebar = False
+	context.no_header = True
+	context.no_footer = True
+
+	convite_name = (frappe.form_dict.get("c") or "").strip()
+	token = (frappe.form_dict.get("t") or "").strip()
+
+	if not _validate_token(convite_name, token):
+		frappe.throw("Página indisponível", frappe.PageDoesNotExistError)
+
+	convite_row = frappe.db.get_value(
+		"Convite Festa",
+		convite_name,
+		[
+			"name",
+			"festa",
+			"email_pagador",
+			"pagador_recebe_qr_codes",
+			"cobranca_infinitepay",
+		],
+		as_dict=True,
+	)
+	if not convite_row:
+		frappe.throw("Página indisponível", frappe.PageDoesNotExistError)
+
+	festa_row = frappe.db.get_value(
+		"Festa",
+		convite_row.festa,
+		["nome_festa", "data", "horario_inicio", "horario_termino"],
+		as_dict=True,
+	) or {}
+
+	cobranca_row = {}
+	if convite_row.cobranca_infinitepay:
+		cobranca_row = frappe.db.get_value(
+			"Cobranca Infinitepay",
+			convite_row.cobranca_infinitepay,
+			["status", "receipt_url"],
+			as_dict=True,
+		) or {}
+
+	status = (cobranca_row.get("status") or "Pendente").strip()
+	if status == STATUS_PAGO:
+		estado = "pago"
+	elif status in STATUS_FALHA:
+		estado = "falha"
+	else:
+		estado = "pendente"
+
+	receipt_url = cobranca_row.get("receipt_url") or ""
+	receipt_url_safe = receipt_url if _is_safe_receipt_url(receipt_url) else ""
+
+	uel_data = get_uel_cached() or {}
+
+	context.estado = estado
+	context.convite_name = convite_row.name
+	context.convite_token = token
+	context.festa = {
+		"nome": festa_row.get("nome_festa") or "",
+		"data": _formatar_data(festa_row.get("data")),
+		"horario_inicio": _formatar_horario(festa_row.get("horario_inicio")),
+		"horario_termino": _formatar_horario(festa_row.get("horario_termino")),
+	}
+	context.pagador_recebe_qr_codes = bool(convite_row.pagador_recebe_qr_codes)
+	context.email_pagador_mascarado = _mask_email(convite_row.email_pagador)
+	context.receipt_url = receipt_url_safe
+	context.portal_logo = uel_data.get("logo")
+	context.uel = {
+		"tipo_uel": uel_data.get("tipo_uel") or "",
+		"nome_da_uel": uel_data.get("nome_da_uel") or "",
+		"numeral": uel_data.get("numeral") or "",
+		"regiao": uel_data.get("regiao") or "",
+	}
+
+
+def _formatar_data(valor) -> str:
+	if not valor:
+		return ""
+	if isinstance(valor, datetime):
+		valor = valor.date()
+	if isinstance(valor, date):
+		return valor.strftime("%d/%m/%Y")
+	return str(valor)
+
+
+def _formatar_horario(valor) -> str:
+	if valor is None or valor == "":
+		return ""
+	if isinstance(valor, timedelta):
+		total = int(valor.total_seconds())
+		horas, resto = divmod(total, 3600)
+		minutos = resto // 60
+		return f"{horas:02d}:{minutos:02d}"
+	if isinstance(valor, time):
+		return valor.strftime("%H:%M")
+	if isinstance(valor, datetime):
+		return valor.strftime("%H:%M")
+	texto = str(valor).strip()
+	if len(texto) >= 5:
+		return texto[:5]
+	return texto

--- a/gris/www/festas/nova_festa.py
+++ b/gris/www/festas/nova_festa.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 
 import frappe
-from frappe.utils import get_time, getdate
+from frappe.utils import add_days, get_time, getdate
 
 from gris.api.portal_access import enrich_context
 from gris.api.portal_cache_utils import get_uel_cached
@@ -125,6 +125,7 @@ def criar_festa(payload):
 	doc = frappe.new_doc("Festa")
 	doc.nome_festa = nome
 	doc.data = data_festa
+	doc.data_limite_vendas = add_days(data_festa, -7)
 	doc.horario_inicio = horario_inicio
 	doc.horario_termino = horario_termino
 	doc.status = "Em andamento"

--- a/gris/www/festas/portaria.html
+++ b/gris/www/festas/portaria.html
@@ -283,7 +283,7 @@ window._portariaData = {
 	<header><h2 id="dlg-portaria-vender-title">Vender na porta</h2></header>
 	<section class="festa-dialog-edit-body portaria-vender-body">
 		<p class="text-sm text-muted-foreground">
-			Escolha como o cliente vai concluir a compra:
+			O cliente pode escanear o QR code abaixo ou você pode abrir a página de venda diretamente.
 		</p>
 		<div class="portaria-vender-acoes">
 			<a class="btn-primary" id="btn-portaria-abrir-venda" href="#" target="_blank" rel="noopener">


### PR DESCRIPTION
This pull request introduces a new secure confirmation flow for party invitations, enhances post-payment WhatsApp notifications, and improves test coverage and reliability. The main changes include a new API module for secure confirmation links, robust helpers and tests, and the addition of WhatsApp notification tracking fields and logic.

**New secure confirmation API and helpers:**

* Added `gris/api/festas/convite_confirmado.py`, which provides HMAC-protected confirmation tokens, redirect URL generation for Infinitepay, a secure AJAX endpoint for payment status polling, and utilities for masking emails and validating receipt URLs. This module is designed to be side-effect free and is only invoked from the relevant page context.
* Created a comprehensive test suite in `gris/api/festas/test_convite_confirmado.py`, covering all helper functions and the AJAX status endpoint, ensuring correct behavior and security.

**WhatsApp notification enhancements:**

* Added a new background job, `enviar_whatsapp_confirmacao_convite`, to `convite_festa.py`, which sends WhatsApp notifications to payers and guests after payment confirmation. The job is idempotent, tracks notification timestamps, and gracefully handles individual message failures.
* Updated the payment webhook handler to enqueue the WhatsApp notification job alongside QR code delivery, ensuring both actions occur after payment.
* Extended the Infinitepay charge creation logic to include the new signed redirect URL.

**Schema and test improvements:**

* Added a hidden, read-only `whatsapp_notificado_em` datetime field to both `Convite Festa` and `Convidado Convite Festa` doctypes, allowing the system to track when WhatsApp notifications are sent and prevent duplicates. [[1]](diffhunk://#diff-3e35daebe129ff7baafae0a62ba39000acddc0755b78f4a535681db3b72abd57L23-R24) [[2]](diffhunk://#diff-3e35daebe129ff7baafae0a62ba39000acddc0755b78f4a535681db3b72abd57R126-R133) [[3]](diffhunk://#diff-142c23afa2bf2056d560b43631764fbdf54f07c638412f277ea724fc4d969ebaL13-R14) [[4]](diffhunk://#diff-142c23afa2bf2056d560b43631764fbdf54f07c638412f277ea724fc4d969ebaR64-R71)
* Improved webhook tests to assert that both WhatsApp and QR code notification jobs are enqueued for the correct invitation, making the test more robust and explicit.
* Fixed test request mocking to ensure a valid host is present for all test cases.