### PR TITLE
Feat/in person party payment

### DIFF
--- a/gris/api/festas/portaria.py
+++ b/gris/api/festas/portaria.py
@@ -168,6 +168,37 @@ def marcar_entrada(festa: str, codigo: str) -> dict:
 
 
 @frappe.whitelist()
+@rate_limit(key="portaria-marcar-manual", limit=30, seconds=60)
+def marcar_entrada_manual(festa: str, codigo: str) -> dict:
+	"""Confirma a entrada de um convidado sem apresentação do QR code.
+
+	Usado quando o convidado realmente comprou o convite mas não tem o QR à
+	mão. Mesma semântica atômica de `marcar_entrada`, mas seta
+	`entrada_manual=1` para auditoria.
+	"""
+	festa = (festa or "").strip()
+	codigo = (codigo or "").strip()
+	if not festa or not codigo:
+		frappe.throw(_("Festa e código são obrigatórios."))
+
+	ensure_user_pode_operar_portaria(festa)
+
+	row = _buscar_por_codigo(festa, codigo)
+	if not row:
+		return {"valido": False}
+
+	resultado = ListaEntradaFesta.marcar_entrada(
+		row.name, user=frappe.session.user, manual=True
+	)
+
+	row = _carregar_entrada(row.name)
+	hidratado = _hidratar_entrada(row, pagador=_dados_pagador(row.convite))
+	hidratado["valido"] = True
+	hidratado["ja_entrou_antes"] = resultado.get("ja_entrou_antes", False)
+	return hidratado
+
+
+@frappe.whitelist()
 def listar_entradas(
 	festa: str,
 	nome: str = "",

--- a/gris/api/festas/portaria.py
+++ b/gris/api/festas/portaria.py
@@ -343,29 +343,40 @@ def reenviar_convite(lista_entrada_name: str) -> dict:
 
 @frappe.whitelist()
 def get_acompanhamento(festa: str) -> dict:
-	"""Métricas para a aba Acompanhamento (pizza + linha por 15min)."""
+	"""Métricas para a aba Acompanhamento (pizza + linha por 15min + origem)."""
 	festa = (festa or "").strip()
 	if not festa:
 		frappe.throw(_("Festa é obrigatória."))
 
 	ensure_user_pode_operar_portaria(festa)
 
-	# Pizza: contagem por status.
-	pizza_rows = frappe.db.sql(
+	# Contagem por (status, presencial). Convites presenciais entram automaticamente
+	# como 'Entrou' no after_insert do Convite Festa, mas são exibidos em uma fatia
+	# separada na pizza ("Comprou na Portaria").
+	contagem_rows = frappe.db.sql(
 		"""
-		SELECT status, COUNT(*) AS qtd
+		SELECT status, presencial, COUNT(*) AS qtd
 		  FROM `tabLista Entrada Festa`
 		 WHERE festa = %s
-		 GROUP BY status
+		 GROUP BY status, presencial
 		""",
 		(festa,),
 		as_dict=True,
 	)
-	pizza = {STATUS_ENTROU: 0, STATUS_NAO_ENTROU: 0}
-	for row in pizza_rows:
-		if row.status in pizza:
-			pizza[row.status] = int(row.qtd or 0)
-	total = pizza[STATUS_ENTROU] + pizza[STATUS_NAO_ENTROU]
+	entrou_previo = 0
+	comprou_portaria = 0
+	nao_entrou = 0
+	for row in contagem_rows:
+		qtd = int(row.qtd or 0)
+		if row.status == STATUS_NAO_ENTROU:
+			nao_entrou += qtd
+		elif row.status == STATUS_ENTROU:
+			if int(row.presencial or 0):
+				comprou_portaria += qtd
+			else:
+				entrou_previo += qtd
+	total = entrou_previo + nao_entrou + comprou_portaria
+	total_entrou = entrou_previo + comprou_portaria
 
 	# Linha: bins de 15 minutos contando entradas.
 	# Truncamento para 15min via floor(unix_timestamp/900)*900.
@@ -399,12 +410,19 @@ def get_acompanhamento(festa: str) -> dict:
 
 	return {
 		"pizza": {
-			"entrou": pizza[STATUS_ENTROU],
-			"nao_entrou": pizza[STATUS_NAO_ENTROU],
+			"entrou": entrou_previo,
+			"nao_entrou": nao_entrou,
+			"comprou_portaria": comprou_portaria,
 			"total": total,
-			"pct_entrou": round((pizza[STATUS_ENTROU] / total) * 100, 1) if total else 0.0,
+			"total_entrou": total_entrou,
+			"pct_entrou": round((total_entrou / total) * 100, 1) if total else 0.0,
 		},
 		"linha": linha,
+		"origem_entradas": {
+			"compra_previa": entrou_previo,
+			"compra_portaria": comprou_portaria,
+			"total_entrou": total_entrou,
+		},
 	}
 
 
@@ -451,4 +469,153 @@ def get_url_venda_porta(festa: str) -> dict:
 				"valor",
 			)
 		),
+	}
+
+
+_MEIOS_PAGAMENTO_PRESENCIAL = ("Dinheiro", "Cartão")
+
+
+def _nome_completo(valor: str) -> bool:
+	return len([p for p in (valor or "").split() if p]) >= 2
+
+
+def _sanitizar_pagador_presencial(pagador) -> dict:
+	if isinstance(pagador, str):
+		try:
+			pagador = frappe.parse_json(pagador) or {}
+		except Exception:
+			frappe.throw(_("Dados do pagador inválidos."))
+	if not isinstance(pagador, dict):
+		frappe.throw(_("Dados do pagador inválidos."))
+	nome = (pagador.get("nome") or "").strip()
+	if not nome:
+		frappe.throw(_("Nome do pagador é obrigatório."))
+	if not _nome_completo(nome):
+		frappe.throw(_("Informe o nome completo do pagador (nome e sobrenome)."))
+	email_raw = (pagador.get("email") or "").strip().lower()
+	email: str | None = None
+	if email_raw:
+		if not EMAIL_REGEX.match(email_raw):
+			frappe.throw(_("E-mail do pagador inválido."))
+		email = email_raw
+	telefone_digits = re.sub(r"\D", "", pagador.get("telefone") or "")
+	telefone: str | None = telefone_digits or None
+	return {"nome": nome, "email": email, "telefone": telefone}
+
+
+def _sanitizar_convidados_presencial(convidados, quantidade: int) -> list[dict]:
+	if isinstance(convidados, str):
+		try:
+			convidados = frappe.parse_json(convidados) or []
+		except Exception:
+			frappe.throw(_("Lista de convidados inválida."))
+	if not isinstance(convidados, list):
+		frappe.throw(_("Lista de convidados inválida."))
+	if len(convidados) != quantidade:
+		frappe.throw(
+			_("Informe exatamente {0} convidado(s) (1 por convite).").format(quantidade)
+		)
+	resultado: list[dict] = []
+	for idx, item in enumerate(convidados, start=1):
+		if not isinstance(item, dict):
+			frappe.throw(_("Convidado #{0} inválido.").format(idx))
+		nome = (item.get("nome") or "").strip()
+		if not nome:
+			frappe.throw(_("Convidado #{0} precisa de nome.").format(idx))
+		if not _nome_completo(nome):
+			frappe.throw(
+				_("Convidado #{0}: informe o nome completo (nome e sobrenome).").format(idx)
+			)
+		resultado.append({"nome": nome})
+	return resultado
+
+
+@frappe.whitelist()
+@rate_limit(key="portaria-presencial", limit=30, seconds=60)
+def criar_convite_presencial(
+	festa: str,
+	pagador,
+	quantidade,
+	meio_pagamento: str,
+	convidados,
+) -> dict:
+	"""Registra uma venda presencial (dinheiro/cartão físico) na portaria.
+
+	- Usa a Opcao Convite Festa ativa com `portaria=1` da festa selecionada.
+	- ACL: somente quem opera a portaria da festa (System Manager, role
+	  Portaria ou coordenador/membro da Area Portaria).
+	- Não cria Cobranca Infinitepay e não dispara e-mail/WhatsApp; a
+	  presença dos convidados é registrada automaticamente pelo
+	  `after_insert` do Convite Festa.
+	"""
+	festa = (festa or "").strip()
+	if not festa:
+		frappe.throw(_("Festa é obrigatória."))
+
+	ensure_user_pode_operar_portaria(festa)
+
+	venda_ativa = frappe.db.get_value("Festa", festa, "venda_na_portaria")
+	if not venda_ativa:
+		frappe.throw(
+			_("O modo 'Venda na portaria' não está ativo para esta festa.")
+		)
+
+	meio_pagamento = (meio_pagamento or "").strip()
+	if meio_pagamento not in _MEIOS_PAGAMENTO_PRESENCIAL:
+		frappe.throw(
+			_("Meio de pagamento inválido: escolha Dinheiro ou Cartão.")
+		)
+
+	try:
+		quantidade_int = int(quantidade)
+	except (TypeError, ValueError):
+		quantidade_int = 0
+	if quantidade_int <= 0:
+		frappe.throw(_("Informe uma quantidade válida (maior que zero)."))
+
+	pagador_data = _sanitizar_pagador_presencial(pagador)
+	convidados_data = _sanitizar_convidados_presencial(convidados, quantidade_int)
+
+	opcao = frappe.db.get_value(
+		"Opcao Convite Festa",
+		{"festa": festa, "portaria": 1, "ativo": 1},
+		["name", "valor"],
+		as_dict=True,
+	)
+	if not opcao:
+		frappe.throw(
+			_("Não há Opção de Convite ativa do tipo Portaria para esta festa.")
+		)
+
+	convite = frappe.get_doc(
+		{
+			"doctype": "Convite Festa",
+			"festa": festa,
+			"nome_pagador": pagador_data["nome"],
+			"email_pagador": pagador_data["email"],
+			"telefone_pagador": pagador_data["telefone"],
+			"presencial": 1,
+			"meio_pagamento": meio_pagamento,
+			# Em venda presencial não enviamos e-mail/QR — mas mantemos a flag
+			# para que `_aplicar_pagador_aos_convidados` não exija e-mail por
+			# convidado.
+			"pagador_recebe_qr_codes": 1,
+			"itens": [
+				{
+					"eh_convite": 1,
+					"opcao_convite": opcao.name,
+					"quantidade": quantidade_int,
+				}
+			],
+			"convidados": [{"nome": c["nome"]} for c in convidados_data],
+		}
+	)
+	convite.insert(ignore_permissions=True)
+	frappe.db.commit()
+
+	return {
+		"ok": True,
+		"convite_name": convite.name,
+		"valor_total": flt(convite.valor_total),
+		"meio_pagamento": convite.meio_pagamento,
 	}

--- a/gris/api/festas/venda_convite.py
+++ b/gris/api/festas/venda_convite.py
@@ -176,13 +176,17 @@ def _validar_pagador(pagador_raw) -> dict:
 
 
 def _validar_convidados(convidados_raw, total_convites: int, pagador_recebe: bool, pagador: dict) -> list[dict]:
-	if pagador_recebe:
-		# O controller gera as linhas a partir do pagador; nada a validar aqui.
-		return []
+	"""Valida e normaliza a lista de convidados.
+
+	Em qualquer cenário o front envia uma linha por convite com pelo menos o
+	nome — a portaria precisa identificar quem entrou. Email e telefone são
+	obrigatórios apenas quando o pagador NÃO recebe todos os QR codes (cada
+	convidado recebe o próprio).
+	"""
 	convidados = _parse_json(convidados_raw, "Lista de convidados")
 	if not isinstance(convidados, list) or len(convidados) != total_convites:
 		frappe.throw(
-			f"Informe os dados de exatamente {total_convites} convidado(s)."
+			f"Informe o nome de exatamente {total_convites} convidado(s)."
 		)
 	saida: list[dict] = []
 	for c in convidados:
@@ -193,6 +197,11 @@ def _validar_convidados(convidados_raw, total_convites: int, pagador_recebe: boo
 		telefone = re.sub(r"\D", "", (c.get("telefone") or ""))
 		if not nome:
 			frappe.throw("Todo convidado precisa de nome.")
+		if pagador_recebe:
+			# QR codes vão todos para o e-mail do pagador; ignoramos email/tel
+			# individuais para evitar coleta desnecessária de dado pessoal.
+			saida.append({"nome": nome, "email": "", "telefone": ""})
+			continue
 		if not email or not EMAIL_REGEX.match(email):
 			frappe.throw(f"E-mail do convidado '{nome}' é inválido.")
 		saida.append({"nome": nome, "email": email, "telefone": telefone})

--- a/gris/festas/doctype/convidado_convite_festa/convidado_convite_festa.json
+++ b/gris/festas/doctype/convidado_convite_festa/convidado_convite_festa.json
@@ -26,8 +26,7 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "E-mail",
-   "options": "Email",
-   "reqd": 1
+   "options": "Email"
   },
   {
    "fieldname": "telefone",

--- a/gris/festas/doctype/convite_festa/convite_festa.json
+++ b/gris/festas/doctype/convite_festa/convite_festa.json
@@ -14,6 +14,8 @@
   "column_break_pagador",
   "email_pagador",
   "secao_pagamento",
+  "presencial",
+  "meio_pagamento",
   "valor_total",
   "status_pagamento",
   "column_break_pagamento",
@@ -61,7 +63,7 @@
    "fieldtype": "Data",
    "label": "Telefone do Pagador",
    "options": "Phone",
-   "reqd": 1
+   "mandatory_depends_on": "eval:!doc.presencial"
   },
   {
    "fieldname": "column_break_pagador",
@@ -72,12 +74,30 @@
    "fieldtype": "Data",
    "label": "E-mail do Pagador",
    "options": "Email",
-   "reqd": 1
+   "mandatory_depends_on": "eval:!doc.presencial"
   },
   {
    "fieldname": "secao_pagamento",
    "fieldtype": "Section Break",
    "label": "Dados do Pagamento"
+  },
+  {
+   "default": "0",
+   "description": "Marcado quando o convite foi vendido na portaria (dinheiro/cartão físico).",
+   "fieldname": "presencial",
+   "fieldtype": "Check",
+   "in_standard_filter": 1,
+   "label": "Pagamento Presencial",
+   "read_only": 1
+  },
+  {
+   "default": "Checkout Infinitepay",
+   "fieldname": "meio_pagamento",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Meio de Pagamento",
+   "options": "Checkout Infinitepay\nDinheiro\nCartão",
+   "reqd": 1
   },
   {
    "fieldname": "valor_total",

--- a/gris/festas/doctype/convite_festa/convite_festa.py
+++ b/gris/festas/doctype/convite_festa/convite_festa.py
@@ -14,6 +14,11 @@ STATUS_ENVIO_PENDENTE = "Pendente"
 STATUS_ENVIO_ENVIADO = "Enviado"
 STATUS_ENVIO_ERRO = "Erro"
 
+MEIO_PAGAMENTO_CHECKOUT = "Checkout Infinitepay"
+MEIO_PAGAMENTO_DINHEIRO = "Dinheiro"
+MEIO_PAGAMENTO_CARTAO = "Cartão"
+MEIOS_PAGAMENTO_PRESENCIAL = (MEIO_PAGAMENTO_DINHEIRO, MEIO_PAGAMENTO_CARTAO)
+
 EMAIL_REGEX = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
 
@@ -22,6 +27,7 @@ class ConviteFesta(Document):
 		self._validar_periodo_de_vendas()
 
 	def validate(self):
+		self._aplicar_meio_pagamento()
 		self._sanitizar_pagador()
 		self._validar_itens()
 		self._calcular_valor_total()
@@ -30,6 +36,10 @@ class ConviteFesta(Document):
 		self._gerar_payloads_qr_code()
 
 	def after_insert(self):
+		if self.presencial:
+			_atualizar_contadores_opcoes(self.name)
+			_criar_lista_entrada(self.name)
+			return
 		self._criar_cobranca_infinitepay()
 
 	def on_trash(self):
@@ -38,7 +48,13 @@ class ConviteFesta(Document):
 
 	@property
 	def status_pagamento(self):
-		"""Virtual field: lê o status diretamente da Cobranca Infinitepay vinculada."""
+		"""Virtual field: lê o status diretamente da Cobranca Infinitepay vinculada.
+
+		Para convites presenciais o pagamento é confirmado no ato da venda
+		(dinheiro/cartão físico), sem cobrança Infinitepay.
+		"""
+		if self.presencial:
+			return STATUS_PAGAMENTO_PAGO
 		if not self.cobranca_infinitepay:
 			return STATUS_ENVIO_PENDENTE
 		return (
@@ -57,18 +73,38 @@ class ConviteFesta(Document):
 		if getdate(today()) > getdate(data_limite):
 			frappe.throw(_("O período de vendas para esta festa foi encerrado."))
 
+	def _aplicar_meio_pagamento(self):
+		"""Garante o invariante meio_pagamento ↔ presencial.
+
+		Convite online: meio_pagamento sempre 'Checkout Infinitepay'.
+		Convite presencial: usuário escolhe entre 'Dinheiro' ou 'Cartão'.
+		"""
+		if not self.presencial:
+			self.meio_pagamento = MEIO_PAGAMENTO_CHECKOUT
+			return
+		if self.meio_pagamento not in MEIOS_PAGAMENTO_PRESENCIAL:
+			frappe.throw(
+				_("Meio de pagamento inválido para venda presencial: escolha Dinheiro ou Cartão.")
+			)
+
 	def _sanitizar_pagador(self):
+		if self.nome_pagador:
+			self.nome_pagador = self.nome_pagador.strip()
+		if not self.nome_pagador:
+			frappe.throw(_("Nome do pagador é obrigatório."))
 		if self.email_pagador:
 			email = self.email_pagador.strip().lower()
 			if not EMAIL_REGEX.match(email):
 				frappe.throw(_("E-mail do pagador inválido."))
 			self.email_pagador = email
+		elif not self.presencial:
+			frappe.throw(_("E-mail do pagador é obrigatório."))
 		if self.telefone_pagador:
 			self.telefone_pagador = re.sub(r"\D", "", self.telefone_pagador)
 			if not self.telefone_pagador:
 				frappe.throw(_("Telefone do pagador inválido."))
-		if self.nome_pagador:
-			self.nome_pagador = self.nome_pagador.strip()
+		elif not self.presencial:
+			frappe.throw(_("Telefone do pagador é obrigatório."))
 
 	def _validar_itens(self):
 		if not self.itens:
@@ -131,6 +167,9 @@ class ConviteFesta(Document):
 		"""Quando o pagador recebe todos os QR codes, a lista de convidados
 		é totalmente gerenciada pelo servidor: garante uma linha por convite
 		preenchida com os dados do pagador, preservando UUIDs já gerados.
+
+		Em vendas presenciais, mantemos os nomes informados pela portaria e
+		não preenchemos email/telefone (não há envio de QR codes).
 		"""
 		if not self.pagador_recebe_qr_codes:
 			return
@@ -138,9 +177,14 @@ class ConviteFesta(Document):
 			int(it.quantidade or 0) for it in self.itens or [] if it.eh_convite
 		)
 		if len(self.convidados or []) != total:
-			self.set("convidados", [])
-			for _ in range(total):
-				self.append("convidados", {})
+			# Em presencial os nomes vêm do formulário; só ajustamos o tamanho
+			# quando ainda não houver convidados (fluxo online).
+			if not self.presencial or not (self.convidados or []):
+				self.set("convidados", [])
+				for _ in range(total):
+					self.append("convidados", {})
+		if self.presencial:
+			return
 		for convidado in self.convidados:
 			convidado.nome = self.nome_pagador
 			convidado.email = self.email_pagador
@@ -160,16 +204,19 @@ class ConviteFesta(Document):
 			)
 
 		for convidado in convidados:
+			if convidado.nome:
+				convidado.nome = convidado.nome.strip()
 			if not convidado.nome:
 				frappe.throw(_("Todo convidado precisa de nome."))
-			if not convidado.email:
+			if convidado.email:
+				email = convidado.email.strip().lower()
+				if not EMAIL_REGEX.match(email):
+					frappe.throw(
+						_("E-mail do convidado '{0}' é inválido.").format(convidado.nome)
+					)
+				convidado.email = email
+			elif not self.presencial:
 				frappe.throw(_("Todo convidado precisa de e-mail."))
-			email = convidado.email.strip().lower()
-			if not EMAIL_REGEX.match(email):
-				frappe.throw(
-					_("E-mail do convidado '{0}' é inválido.").format(convidado.nome)
-				)
-			convidado.email = email
 			if convidado.telefone:
 				convidado.telefone = re.sub(r"\D", "", convidado.telefone)
 
@@ -294,6 +341,7 @@ def _criar_lista_entrada(convite_name: str) -> None:
 			doc.nome_convidado = convidado.nome
 			doc.email = convidado.email
 			doc.telefone = convidado.telefone
+			doc.presencial = 1 if convite.presencial else 0
 			if eh_portaria:
 				doc.status = "Entrou"
 				doc.hora_entrada = now()

--- a/gris/festas/doctype/convite_festa/convite_festa.py
+++ b/gris/festas/doctype/convite_festa/convite_festa.py
@@ -67,9 +67,7 @@ class ConviteFesta(Document):
 	def _validar_periodo_de_vendas(self):
 		data_limite = frappe.db.get_value("Festa", self.festa, "data_limite_vendas")
 		if not data_limite:
-			frappe.throw(
-				_("A festa selecionada não possui data limite de vendas configurada.")
-			)
+			frappe.throw(_("A festa selecionada não possui data limite de vendas configurada."))
 		if getdate(today()) > getdate(data_limite):
 			frappe.throw(_("O período de vendas para esta festa foi encerrado."))
 
@@ -83,9 +81,7 @@ class ConviteFesta(Document):
 			self.meio_pagamento = MEIO_PAGAMENTO_CHECKOUT
 			return
 		if self.meio_pagamento not in MEIOS_PAGAMENTO_PRESENCIAL:
-			frappe.throw(
-				_("Meio de pagamento inválido para venda presencial: escolha Dinheiro ou Cartão.")
-			)
+			frappe.throw(_("Meio de pagamento inválido para venda presencial: escolha Dinheiro ou Cartão."))
 
 	def _sanitizar_pagador(self):
 		if self.nome_pagador:
@@ -117,9 +113,7 @@ class ConviteFesta(Document):
 			if item.eh_convite:
 				tem_convite = True
 				if not item.opcao_convite:
-					frappe.throw(
-						_("Item de convite precisa ter uma Opção de Convite vinculada.")
-					)
+					frappe.throw(_("Item de convite precisa ter uma Opção de Convite vinculada."))
 				opcao = frappe.db.get_value(
 					"Opcao Convite Festa",
 					item.opcao_convite,
@@ -130,23 +124,15 @@ class ConviteFesta(Document):
 					frappe.throw(_("Opção de Convite inválida no item."))
 				if opcao.festa != self.festa:
 					frappe.throw(
-						_("A Opção de Convite '{0}' pertence a outra festa.").format(
-							item.opcao_convite
-						)
+						_("A Opção de Convite '{0}' pertence a outra festa.").format(item.opcao_convite)
 					)
 				if not opcao.ativo:
-					frappe.throw(
-						_("A Opção de Convite '{0}' está inativa.").format(item.opcao_convite)
-					)
+					frappe.throw(_("A Opção de Convite '{0}' está inativa.").format(item.opcao_convite))
 				item.descricao = opcao.nome_convite
 				item.valor = opcao.valor
 			else:
 				if not aceitar_doacoes:
-					frappe.throw(
-						_(
-							"A festa selecionada não aceita doações junto com os convites."
-						)
-					)
+					frappe.throw(_("A festa selecionada não aceita doações junto com os convites."))
 				item.opcao_convite = None
 				if not item.descricao:
 					frappe.throw(_("Item sem descrição."))
@@ -164,36 +150,25 @@ class ConviteFesta(Document):
 		self.valor_total = total
 
 	def _aplicar_pagador_aos_convidados(self):
-		"""Quando o pagador recebe todos os QR codes, a lista de convidados
-		é totalmente gerenciada pelo servidor: garante uma linha por convite
-		preenchida com os dados do pagador, preservando UUIDs já gerados.
-
-		Em vendas presenciais, mantemos os nomes informados pela portaria e
-		não preenchemos email/telefone (não há envio de QR codes).
+		"""Quando o pagador recebe todos os QR codes, garantimos que existe
+		uma linha de Convidado Convite Festa por convite (criando vazias
+		quando faltar), mas o nome de cada convidado vem do formulário e
+		email/telefone permanecem em branco — o envio do QR vai todo para o
+		e-mail do pagador.
 		"""
 		if not self.pagador_recebe_qr_codes:
 			return
-		total = sum(
-			int(it.quantidade or 0) for it in self.itens or [] if it.eh_convite
-		)
-		if len(self.convidados or []) != total:
-			# Em presencial os nomes vêm do formulário; só ajustamos o tamanho
-			# quando ainda não houver convidados (fluxo online).
-			if not self.presencial or not (self.convidados or []):
-				self.set("convidados", [])
-				for _ in range(total):
-					self.append("convidados", {})
-		if self.presencial:
-			return
-		for convidado in self.convidados:
-			convidado.nome = self.nome_pagador
-			convidado.email = self.email_pagador
-			convidado.telefone = self.telefone_pagador
+		total = sum(int(it.quantidade or 0) for it in self.itens or [] if it.eh_convite)
+		# Só ajustamos o tamanho quando ainda não houver convidados (cobre o
+		# caso degenerado de fluxos legados); a coleta do nome é responsabilidade
+		# do front, que envia uma linha por convite.
+		if not (self.convidados or []) and total:
+			self.set("convidados", [])
+			for _ in range(total):
+				self.append("convidados", {})
 
 	def _validar_convidados(self):
-		total_convites = sum(
-			int(it.quantidade or 0) for it in self.itens if it.eh_convite
-		)
+		total_convites = sum(int(it.quantidade or 0) for it in self.itens if it.eh_convite)
 		convidados = list(self.convidados or [])
 
 		if len(convidados) != total_convites:
@@ -211,11 +186,9 @@ class ConviteFesta(Document):
 			if convidado.email:
 				email = convidado.email.strip().lower()
 				if not EMAIL_REGEX.match(email):
-					frappe.throw(
-						_("E-mail do convidado '{0}' é inválido.").format(convidado.nome)
-					)
+					frappe.throw(_("E-mail do convidado '{0}' é inválido.").format(convidado.nome))
 				convidado.email = email
-			elif not self.presencial:
+			elif not self.presencial and not self.pagador_recebe_qr_codes:
 				frappe.throw(_("Todo convidado precisa de e-mail."))
 			if convidado.telefone:
 				convidado.telefone = re.sub(r"\D", "", convidado.telefone)
@@ -250,9 +223,7 @@ class ConviteFesta(Document):
 				],
 			}
 		).insert(ignore_permissions=True)
-		frappe.db.set_value(
-			self.doctype, self.name, "cobranca_infinitepay", cobranca.name
-		)
+		frappe.db.set_value(self.doctype, self.name, "cobranca_infinitepay", cobranca.name)
 		self.cobranca_infinitepay = cobranca.name
 
 
@@ -341,6 +312,9 @@ def _criar_lista_entrada(convite_name: str) -> None:
 			doc.nome_convidado = convidado.nome
 			doc.email = convidado.email
 			doc.telefone = convidado.telefone
+			doc.nome_pagador = convite.nome_pagador
+			doc.email_pagador = convite.email_pagador
+			doc.telefone_pagador = convite.telefone_pagador
 			doc.presencial = 1 if convite.presencial else 0
 			if eh_portaria:
 				doc.status = "Entrou"
@@ -370,14 +344,9 @@ def _atualizar_contadores_opcoes(convite_name: str) -> None:
 	for item in itens:
 		if not item.opcao_convite:
 			continue
-		agregado[item.opcao_convite] = agregado.get(item.opcao_convite, 0) + int(
-			item.quantidade or 0
-		)
+		agregado[item.opcao_convite] = agregado.get(item.opcao_convite, 0) + int(item.quantidade or 0)
 	for opcao_name, quantidade in agregado.items():
-		atual = (
-			frappe.db.get_value("Opcao Convite Festa", opcao_name, "quantidade_vendida")
-			or 0
-		)
+		atual = frappe.db.get_value("Opcao Convite Festa", opcao_name, "quantidade_vendida") or 0
 		frappe.db.set_value(
 			"Opcao Convite Festa",
 			opcao_name,
@@ -432,9 +401,7 @@ def enviar_qr_codes(
 		envio_individual_forcado = False
 	else:
 		pendentes = [
-			c
-			for c in (doc.convidados or [])
-			if c.status_envio in (STATUS_ENVIO_PENDENTE, STATUS_ENVIO_ERRO)
+			c for c in (doc.convidados or []) if c.status_envio in (STATUS_ENVIO_PENDENTE, STATUS_ENVIO_ERRO)
 		]
 		envio_individual_forcado = False
 	if not pendentes:
@@ -522,9 +489,7 @@ def _carregar_template(doc, festa) -> dict:
 		"_template_subject": template.subject,
 		# response é armazenado com entidades HTML escapadas (&gt;, &lt;);
 		# o Jinja precisa do operador original para parsear corretamente.
-		"_template_response": (template.response or "")
-		.replace("&gt;", ">")
-		.replace("&lt;", "<"),
+		"_template_response": (template.response or "").replace("&gt;", ">").replace("&lt;", "<"),
 	}
 
 
@@ -556,12 +521,8 @@ def _safe_filename(festa_nome: str, convidado_nome: str) -> str:
 	return f"convite_{parte_festa}_{parte_conv}.pdf"
 
 
-def _mensagem_whatsapp_erro(
-	convite_name: str, festa_nome: str, falhas: list[tuple[str, str, str]]
-) -> str:
-	linhas = "\n".join(
-		f"- {nome} ({email}): {erro[:120]}" for nome, email, erro in falhas
-	)
+def _mensagem_whatsapp_erro(convite_name: str, festa_nome: str, falhas: list[tuple[str, str, str]]) -> str:
+	linhas = "\n".join(f"- {nome} ({email}): {erro[:120]}" for nome, email, erro in falhas)
 	return (
 		f"[GRIS] Falha ao enviar QR codes do Convite Festa {convite_name} "
 		f"({festa_nome}).\nConvidados em erro:\n{linhas}"
@@ -603,18 +564,21 @@ def enviar_whatsapp_confirmacao_convite(convite_name: str) -> None:
 	if not doc.whatsapp_notificado_em and doc.telefone_pagador:
 		if pagador_recebe_tudo:
 			mensagem_pagador = (
-				f"Olá, {primeiro_nome_pagador}!\n"
-				f"Recebemos o pagamento da sua compra de {qtd_convites} convite(s) para {festa_nome}.\n"
-				f"Em breve você receberá os convites no e-mail {_mask_email(doc.email_pagador)}.\n"
-				"Apresente-os na entrada da festa.\n"
-				f"Confirmação e recibo: {link_assinado}"
+				f"Olá, {primeiro_nome_pagador}!\n\n"
+				f"Recebemos o pagamento da sua compra de {qtd_convites} convite(s) para {festa_nome}.\n\n"
+				f"Em breve você receberá os convites no e-mail {_mask_email(doc.email_pagador)}.\n\n"
+				"Para entrar na festa você precisará apresentar os convites. Não se esqueça de salvá-los em um lugar de fácil acesso para não ter problemas na entrada, combinado?!\n\n"
+				f"Aqui está a confirmação de sua compra: {link_assinado}"
+				"\n\nNos vemos na festa! 🎉"
 			)
 		else:
 			mensagem_pagador = (
-				f"Olá, {primeiro_nome_pagador}!\n"
-				f"Recebemos o pagamento da sua compra de {qtd_convites} convite(s) para {festa_nome}.\n"
-				"Cada convidado receberá seu convite no e-mail informado.\n"
-				f"Confirmação e recibo: {link_assinado}"
+				f"Olá, {primeiro_nome_pagador}!\n\n"
+				f"Recebemos o pagamento da sua compra de {qtd_convites} convite(s) para {festa_nome}.\n\n"
+				"Cada convidado receberá seu convite no e-mail informado.\n\n"
+				"Para entrar na festa cada convidado precisará apresentar os convites, lembre-se de deixar seu convite em um lugar de fácil acesso para não ter problemas na entrada, combinado?!\n\n"
+				f"Aqui está a confirmação de sua compra: {link_assinado}"
+				"\n\nNos vemos na festa! 🎉"
 			)
 		try:
 			enviar_texto(doc.telefone_pagador, mensagem_pagador)

--- a/gris/festas/doctype/lista_entrada_festa/lista_entrada_festa.json
+++ b/gris/festas/doctype/lista_entrada_festa/lista_entrada_festa.json
@@ -14,6 +14,7 @@
   "status",
   "hora_entrada",
   "entrada_registrada_por",
+  "presencial",
   "secao_convidado",
   "nome_convidado",
   "column_break_convidado",
@@ -82,6 +83,15 @@
    "fieldtype": "Link",
    "label": "Entrada Registrada Por",
    "options": "User",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "description": "Marcado quando o convite associado foi vendido presencialmente na portaria.",
+   "fieldname": "presencial",
+   "fieldtype": "Check",
+   "in_standard_filter": 1,
+   "label": "Comprou na Portaria",
    "read_only": 1
   },
   {

--- a/gris/festas/doctype/lista_entrada_festa/lista_entrada_festa.json
+++ b/gris/festas/doctype/lista_entrada_festa/lista_entrada_festa.json
@@ -14,12 +14,18 @@
   "status",
   "hora_entrada",
   "entrada_registrada_por",
+  "entrada_manual",
   "presencial",
   "secao_convidado",
   "nome_convidado",
   "column_break_convidado",
   "email",
-  "telefone"
+  "telefone",
+  "secao_pagador",
+  "nome_pagador",
+  "column_break_pagador",
+  "email_pagador",
+  "telefone_pagador"
  ],
  "fields": [
   {
@@ -87,6 +93,15 @@
   },
   {
    "default": "0",
+   "description": "Marcado quando a entrada foi confirmada manualmente pela portaria, sem apresentação do QR code.",
+   "fieldname": "entrada_manual",
+   "fieldtype": "Check",
+   "in_standard_filter": 1,
+   "label": "Entrada Manual",
+   "read_only": 1
+  },
+  {
+   "default": "0",
    "description": "Marcado quando o convite associado foi vendido presencialmente na portaria.",
    "fieldname": "presencial",
    "fieldtype": "Check",
@@ -121,6 +136,35 @@
    "fieldtype": "Data",
    "label": "Telefone",
    "options": "Phone"
+  },
+  {
+   "fieldname": "secao_pagador",
+   "fieldtype": "Section Break",
+   "label": "Dados do Pagador"
+  },
+  {
+   "fieldname": "nome_pagador",
+   "fieldtype": "Data",
+   "label": "Nome do Pagador",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_pagador",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "email_pagador",
+   "fieldtype": "Data",
+   "label": "E-mail do Pagador",
+   "options": "Email",
+   "read_only": 1
+  },
+  {
+   "fieldname": "telefone_pagador",
+   "fieldtype": "Data",
+   "label": "Telefone do Pagador",
+   "options": "Phone",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,

--- a/gris/festas/doctype/lista_entrada_festa/lista_entrada_festa.py
+++ b/gris/festas/doctype/lista_entrada_festa/lista_entrada_festa.py
@@ -46,12 +46,15 @@ class ListaEntradaFesta(Document):
 			self.entrada_registrada_por = None
 
 	@staticmethod
-	def marcar_entrada(name: str, user: str | None = None) -> dict:
+	def marcar_entrada(name: str, user: str | None = None, manual: bool = False) -> dict:
 		"""Marca uma entrada de forma atômica (evita race condition em duplo scan).
 
 		Atualiza apenas se status atual = 'Não entrou'. Retorna:
 		- {ok: True, ja_entrou_antes: False, hora_entrada}  se efetivou
 		- {ok: True, ja_entrou_antes: True, hora_entrada, registrado_por} se já tinha entrado
+
+		`manual=True` quando a entrada foi confirmada pela portaria sem QR
+		code; grava `entrada_manual=1` para auditoria.
 		"""
 		from frappe.utils import now
 
@@ -66,6 +69,7 @@ class ListaEntradaFesta(Document):
 			   SET status = %(status)s,
 			       hora_entrada = %(agora)s,
 			       entrada_registrada_por = %(user)s,
+			       entrada_manual = %(manual)s,
 			       modified = %(agora)s,
 			       modified_by = %(user)s
 			 WHERE name = %(name)s
@@ -76,6 +80,7 @@ class ListaEntradaFesta(Document):
 				"status_atual": STATUS_NAO_ENTROU,
 				"agora": agora,
 				"user": user,
+				"manual": 1 if manual else 0,
 				"name": name,
 			},
 		)

--- a/gris/www/festas/portaria.css
+++ b/gris/www/festas/portaria.css
@@ -261,7 +261,34 @@
 .portaria-dialog-footer {
 	display: flex;
 	justify-content: flex-end;
+	flex-wrap: wrap;
 	gap: 0.5rem;
+}
+
+/* Dialog de detalhes do convidado: 4 botões no rodapé apertam o tamanho
+ * padrão do Basecoat (32rem). Damos um pouco mais de largura no desktop. */
+#dlg-portaria-detalhes > * {
+	max-width: 44rem;
+}
+
+@media (max-width: 640px) {
+	/* No mobile, garante margem lateral (a base do Basecoat fica 100%) e
+	 * empilha/reordena os botões: editar, reenviar, entrada manual, fechar. */
+	#dlg-portaria-detalhes > * {
+		max-width: calc(100% - 2rem);
+	}
+	#dlg-portaria-detalhes .portaria-dialog-footer {
+		flex-direction: column;
+		align-items: stretch;
+	}
+	#dlg-portaria-detalhes .portaria-dialog-footer > button {
+		width: 100%;
+		justify-content: center;
+	}
+	#dlg-portaria-detalhes #btn-portaria-det-editar { order: 1; }
+	#dlg-portaria-detalhes #btn-portaria-det-reenviar { order: 2; }
+	#dlg-portaria-detalhes #btn-portaria-det-entrada-manual { order: 3; }
+	#dlg-portaria-detalhes .portaria-dialog-footer > .btn-primary { order: 4; }
 }
 
 .portaria-vender-body {

--- a/gris/www/festas/portaria.css
+++ b/gris/www/festas/portaria.css
@@ -146,6 +146,53 @@
 	gap: 0.75rem;
 }
 
+.portaria-card--span-2 {
+	grid-column: 1 / -1;
+}
+
+.portaria-indicadores-row {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 1rem;
+	margin-bottom: 1.5rem;
+}
+
+.portaria-card--indicador {
+	gap: 0.25rem;
+	align-items: flex-start;
+	width: auto;
+	min-width: 14rem;
+	max-width: 22rem;
+	flex: 0 0 auto;
+}
+
+@media (max-width: 640px) {
+	.portaria-card--indicador {
+		width: 100%;
+		max-width: none;
+	}
+}
+
+.portaria-card__indicador-label {
+	margin: 0;
+	font-size: 0.875rem;
+	color: var(--muted-foreground, #6b7280);
+}
+
+.portaria-card__indicador-valor {
+	margin: 0;
+	font-size: 2.25rem;
+	font-weight: 700;
+	line-height: 1.1;
+	color: var(--foreground, #111827);
+}
+
+.portaria-card__indicador-extra {
+	margin: 0.125rem 0 0;
+	font-size: 0.8125rem;
+	color: var(--muted-foreground, #6b7280);
+}
+
 .portaria-card__title {
 	font-size: 1rem;
 	font-weight: 600;
@@ -337,4 +384,221 @@
 	background: transparent;
 	border-color: transparent;
 	padding: 0.25rem 0;
+}
+
+/* ─── Vender na porta: cards de modo (Link x Presencial) ─── */
+.portaria-modo-cards {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 1rem;
+}
+
+@media (max-width: 640px) {
+	.portaria-modo-cards {
+		grid-template-columns: 1fr;
+	}
+}
+
+.portaria-modo-card {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 1.25rem 1rem;
+	border-radius: 0.75rem;
+	border: 1px solid var(--border, #d1d5db);
+	background: var(--background, #fff);
+	color: var(--foreground, #111827);
+	cursor: pointer;
+	text-align: center;
+	transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.08s ease;
+}
+
+.portaria-modo-card:hover {
+	border-color: var(--primary, #1d4ed8);
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.portaria-modo-card:active {
+	transform: scale(0.99);
+}
+
+.portaria-modo-card svg {
+	width: 2.5rem;
+	height: 2.5rem;
+	color: var(--primary, #1d4ed8);
+}
+
+.portaria-modo-card--primary {
+	border-color: var(--primary, #1d4ed8);
+	box-shadow: 0 0 0 1px var(--primary, #1d4ed8) inset;
+}
+
+.portaria-modo-card__badge {
+	position: absolute;
+	top: 0.5rem;
+	right: 0.5rem;
+	font-size: 0.6875rem;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	padding: 0.125rem 0.5rem;
+	background: var(--primary, #1d4ed8);
+	color: var(--primary-foreground, #fff);
+	border-radius: 999px;
+}
+
+.portaria-modo-card__titulo {
+	font-size: 1rem;
+	font-weight: 600;
+}
+
+.portaria-modo-card__descricao {
+	font-size: 0.8125rem;
+	color: var(--muted-foreground, #6b7280);
+}
+
+/* ─── Dialog presencial: cards de forma de pagamento ─── */
+.portaria-presencial-body {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.portaria-presencial-card {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+}
+
+.portaria-presencial-card__titulo {
+	font-size: 0.95rem;
+	font-weight: 600;
+	margin: 0;
+}
+
+.portaria-quantidade-wrapper {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 0.5rem;
+}
+
+.portaria-quantidade {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+}
+
+.portaria-quantidade__btn {
+	width: 2.5rem;
+	height: 2.5rem;
+	font-size: 1.25rem;
+	font-weight: 700;
+}
+
+.portaria-quantidade__input {
+	width: 5rem;
+	text-align: center;
+	font-size: 1.125rem;
+	font-weight: 600;
+	padding: 0.5rem;
+	border: 1px solid var(--border, #d1d5db);
+	border-radius: 0.5rem;
+	background: var(--background, #fff);
+	color: var(--foreground, #111827);
+}
+
+.portaria-quantidade__preco {
+	margin: 0;
+	text-align: center;
+}
+
+.portaria-presencial-stack {
+	display: flex;
+	flex-direction: column;
+	gap: 1.25rem;
+}
+
+.portaria-presencial-field {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+}
+
+.portaria-presencial-hint {
+	margin: 0;
+}
+
+.portaria-presencial-erro {
+	margin: 0;
+	color: var(--destructive, #dc2626);
+}
+
+.portaria-presencial-field--erro input,
+.portaria-presencial-field--erro [data-phone-input-number],
+.portaria-presencial-field--erro [role="combobox"] {
+	border-color: var(--destructive, #dc2626) !important;
+	box-shadow: 0 0 0 1px var(--destructive, #dc2626) inset;
+}
+
+.portaria-meio-cards.portaria-presencial-field--erro .portaria-meio-card {
+	border-color: var(--destructive, #dc2626);
+}
+
+.portaria-meio-cards {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 0.75rem;
+}
+
+.portaria-meio-card {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 0.375rem;
+	padding: 1rem;
+	border-radius: 0.75rem;
+	border: 1px solid var(--border, #d1d5db);
+	background: var(--background, #fff);
+	color: var(--foreground, #111827);
+	cursor: pointer;
+	transition: border-color 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.portaria-meio-card:hover {
+	border-color: var(--primary, #1d4ed8);
+}
+
+.portaria-meio-card svg {
+	width: 1.75rem;
+	height: 1.75rem;
+}
+
+.portaria-meio-card__titulo {
+	font-size: 0.95rem;
+	font-weight: 600;
+}
+
+.portaria-meio-card--ativo {
+	border-color: var(--primary, #1d4ed8);
+	background: rgba(29, 78, 216, 0.06);
+	box-shadow: 0 0 0 1px var(--primary, #1d4ed8) inset;
+}
+
+.portaria-presencial-total {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 1rem;
+	padding: 0.875rem 1rem;
+	border-radius: 0.75rem;
+	background: var(--muted, #f3f4f6);
+	font-size: 1rem;
+}
+
+.portaria-presencial-total strong {
+	font-size: 1.25rem;
+	color: var(--foreground, #111827);
 }

--- a/gris/www/festas/portaria.html
+++ b/gris/www/festas/portaria.html
@@ -484,6 +484,23 @@ window._portariaData = {
 			</div>
 		</section>
 		<section class="portaria-section">
+			<h3 class="portaria-section__title">Dados do pagador</h3>
+			<div class="portaria-detail-grid">
+				<div class="portaria-detail-field">
+					<span class="portaria-detail-field__label">Nome</span>
+					<span class="portaria-detail-field__value" id="portaria-det-pagador-nome">—</span>
+				</div>
+				<div class="portaria-detail-field">
+					<span class="portaria-detail-field__label">E-mail</span>
+					<span class="portaria-detail-field__value" id="portaria-det-pagador-email">—</span>
+				</div>
+				<div class="portaria-detail-field">
+					<span class="portaria-detail-field__label">Telefone</span>
+					<span class="portaria-detail-field__value" id="portaria-det-pagador-telefone">—</span>
+				</div>
+			</div>
+		</section>
+		<section class="portaria-section">
 			<h3 class="portaria-section__title">Dados do convite</h3>
 			<div class="portaria-detail-grid">
 				<div class="portaria-detail-field">
@@ -522,6 +539,10 @@ window._portariaData = {
 		<button type="button" class="btn-outline" id="btn-portaria-det-editar">
 			{{ lucide_icon("pencil", size="sm") }}
 			<span>Editar</span>
+		</button>
+		<button type="button" class="btn-destructive" id="btn-portaria-det-entrada-manual" hidden>
+			{{ lucide_icon("user-check", size="sm") }}
+			<span>Entrada Manual</span>
 		</button>
 		<button type="button" class="btn-primary" onclick="this.closest('dialog').close()">Fechar</button>
 	</footer>

--- a/gris/www/festas/portaria.html
+++ b/gris/www/festas/portaria.html
@@ -4,6 +4,7 @@
 {% from "public/design_system/components/generated/dialog.html.jinja" import dialog %}
 {% from "public/design_system/components/generated/select.html.jinja" import select %}
 {% from "public/design_system/components/generated/toast.html.jinja" import toaster %}
+{% from "public/design_system/components/generated/phone-input.html.jinja" import phone_input %}
 {% from "public/design_system/components/composed/lucide.html.jinja" import lucide_icon %}
 
 {% block title %}Portaria{% endblock %}
@@ -111,13 +112,26 @@ window._portariaData = {
 
 {% set tab_acompanhamento %}
 <div class="portaria-tab-content">
+	<div class="portaria-indicadores-row">
+		{% call card(attrs={"class": "portaria-card portaria-card--indicador"}) %}
+		<p class="portaria-card__indicador-label">Total de convidados que entraram</p>
+		<p class="portaria-card__indicador-valor" id="portaria-indicador-total-valor">—</p>
+		<p class="portaria-card__indicador-extra" id="portaria-indicador-total-extra">—</p>
+		{% endcall %}
+	</div>
+
 	<div class="portaria-charts-grid">
 		{% call card(attrs={"class": "portaria-card"}) %}
 		<h3 class="portaria-card__title">Entradas confirmadas</h3>
-		<div id="chart-portaria-pizza" class="portaria-chart" aria-label="Gráfico de entradas confirmadas (Entrou vs Não entrou)"></div>
+		<div id="chart-portaria-pizza" class="portaria-chart" aria-label="Gráfico de entradas confirmadas (Entrou, Não entrou, Comprou na Portaria)"></div>
 		{% endcall %}
 
 		{% call card(attrs={"class": "portaria-card"}) %}
+		<h3 class="portaria-card__title">Origem das entradas</h3>
+		<div id="chart-portaria-origem" class="portaria-chart" aria-label="Gráfico de origem das entradas (Compra Prévia vs Compra na Portaria)"></div>
+		{% endcall %}
+
+		{% call card(attrs={"class": "portaria-card portaria-card--span-2"}) %}
 		<div class="portaria-chart-header">
 			<h3 class="portaria-card__title">Entradas por janela de 15 min</h3>
 			<div class="portaria-chart-actions">
@@ -278,9 +292,36 @@ window._portariaData = {
 </div>
 </dialog>
 
-<dialog id="dlg-portaria-vender" class="dialog" aria-labelledby="dlg-portaria-vender-title" onclick="if (event.target === this) this.close()">
+<dialog id="dlg-portaria-vender-modo" class="dialog" aria-labelledby="dlg-portaria-vender-modo-title" onclick="if (event.target === this) this.close()">
 <div>
-	<header><h2 id="dlg-portaria-vender-title">Vender na porta</h2></header>
+	<header><h2 id="dlg-portaria-vender-modo-title">Vender na porta</h2></header>
+	<section class="festa-dialog-edit-body">
+		<p class="text-sm text-muted-foreground">
+			Como o cliente vai pagar?
+		</p>
+		<div class="portaria-modo-cards">
+			<button type="button" class="portaria-modo-card portaria-modo-card--primary" id="btn-portaria-modo-link" data-modo="link">
+				<span class="portaria-modo-card__badge">Recomendado</span>
+				{{ lucide_icon("qr-code", size="lg") }}
+				<span class="portaria-modo-card__titulo">Link de pagamento</span>
+				<span class="portaria-modo-card__descricao">O cliente escaneia o QR code e paga online (Pix, cartão ou Infinitepay).</span>
+			</button>
+			<button type="button" class="portaria-modo-card" id="btn-portaria-modo-presencial" data-modo="presencial">
+				{{ lucide_icon("wallet", size="lg") }}
+				<span class="portaria-modo-card__titulo">Dinheiro ou Cartão presencial</span>
+				<span class="portaria-modo-card__descricao">Recebido na hora, em dinheiro ou cartão físico. A entrada é confirmada automaticamente.</span>
+			</button>
+		</div>
+	</section>
+	<footer>
+		<button type="button" class="btn-outline" onclick="this.closest('dialog').close()">Cancelar</button>
+	</footer>
+</div>
+</dialog>
+
+<dialog id="dlg-portaria-vender-link" class="dialog" aria-labelledby="dlg-portaria-vender-link-title" onclick="if (event.target === this) this.close()">
+<div>
+	<header><h2 id="dlg-portaria-vender-link-title">Link de pagamento</h2></header>
 	<section class="festa-dialog-edit-body portaria-vender-body">
 		<p class="text-sm text-muted-foreground">
 			O cliente pode escanear o QR code abaixo ou você pode abrir a página de venda diretamente.
@@ -298,6 +339,103 @@ window._portariaData = {
 	</section>
 	<footer>
 		<button type="button" class="btn-outline" onclick="this.closest('dialog').close()">Fechar</button>
+	</footer>
+</div>
+</dialog>
+
+<dialog id="dlg-portaria-vender-presencial" class="dialog" aria-labelledby="dlg-portaria-vender-presencial-title" onclick="if (event.target === this) this.close()">
+<div>
+	<header><h2 id="dlg-portaria-vender-presencial-title">Venda presencial</h2></header>
+	<section class="festa-dialog-edit-body portaria-presencial-body">
+		{% call card(attrs={"class": "portaria-presencial-card"}) %}
+		<h3 class="portaria-presencial-card__titulo">Quantidade de convites</h3>
+		<div class="portaria-quantidade-wrapper">
+			<div class="portaria-quantidade">
+				<button type="button" class="btn-sm-outline portaria-quantidade__btn" id="btn-presencial-quantidade-menos" aria-label="Diminuir quantidade">−</button>
+				<input type="number" inputmode="numeric" min="1" step="1" value="1" id="presencial-quantidade" class="portaria-quantidade__input" />
+				<button type="button" class="btn-sm-outline portaria-quantidade__btn" id="btn-presencial-quantidade-mais" aria-label="Aumentar quantidade">+</button>
+			</div>
+			<p class="text-sm text-muted-foreground portaria-quantidade__preco">Valor unitário: <span id="presencial-preco-unitario">—</span></p>
+		</div>
+		{% endcall %}
+
+		{% call card(attrs={"class": "portaria-presencial-card"}) %}
+		<h3 class="portaria-presencial-card__titulo">Pagador</h3>
+		<div class="portaria-presencial-stack">
+			<div class="portaria-presencial-field" id="presencial-pagador-nome-wrap">
+				{% call field(label="Nome completo *") %}
+					{{ input(attrs={"id": "presencial-pagador-nome", "required": "required", "autocomplete": "name", "placeholder": "Ex.: Maria Silva"}) }}
+				{% endcall %}
+				<p class="text-xs text-muted-foreground portaria-presencial-hint">Informe nome e sobrenome.</p>
+				<p class="text-xs text-destructive portaria-presencial-erro" id="presencial-pagador-nome-erro" hidden></p>
+			</div>
+			<div class="portaria-presencial-field" id="presencial-pagador-email-wrap">
+				{% call field(label="E-mail (opcional)") %}
+					{{ input(type="email", attrs={"id": "presencial-pagador-email", "autocomplete": "email"}) }}
+				{% endcall %}
+				<p class="text-xs text-destructive portaria-presencial-erro" id="presencial-pagador-email-erro" hidden></p>
+			</div>
+			<div class="portaria-presencial-field" id="presencial-pagador-telefone-wrap">
+				{% call field(label="Telefone (opcional)") %}
+					{{ phone_input(
+						id="presencial-pagador-telefone",
+						name="presencial-pagador-telefone",
+						default_country="BR",
+						placeholder="(11) 91234-5678",
+						input_attrs={"id": "presencial-pagador-telefone-number"}
+					) }}
+				{% endcall %}
+				<p class="text-xs text-destructive portaria-presencial-erro" id="presencial-pagador-telefone-erro" hidden></p>
+			</div>
+		</div>
+		{% endcall %}
+
+		{% call card(attrs={"class": "portaria-presencial-card"}) %}
+		<h3 class="portaria-presencial-card__titulo">Forma de pagamento</h3>
+		<div class="portaria-meio-cards" role="radiogroup" aria-label="Forma de pagamento" id="presencial-meio-wrap">
+			<button type="button" class="portaria-meio-card" role="radio" aria-checked="false" data-meio="Dinheiro" id="btn-presencial-meio-dinheiro">
+				{{ lucide_icon("banknote", size="lg") }}
+				<span class="portaria-meio-card__titulo">Dinheiro</span>
+			</button>
+			<button type="button" class="portaria-meio-card" role="radio" aria-checked="false" data-meio="Cartão" id="btn-presencial-meio-cartao">
+				{{ lucide_icon("credit-card", size="lg") }}
+				<span class="portaria-meio-card__titulo">Cartão</span>
+			</button>
+		</div>
+		<p class="text-xs text-destructive portaria-presencial-erro" id="presencial-meio-erro" hidden></p>
+		{% endcall %}
+
+		{% call card(attrs={"class": "portaria-presencial-card"}) %}
+		<h3 class="portaria-presencial-card__titulo">Convidados</h3>
+		<p class="text-sm text-muted-foreground">Informe o nome completo de cada convidado (nome e sobrenome).</p>
+		<div id="presencial-galeria" class="vc-galeria">
+			<header class="vc-galeria__header">
+				<button type="button" class="btn-sm-outline" id="presencial-galeria-prev" aria-label="Convidado anterior">‹</button>
+				<span class="vc-galeria__indicator" id="presencial-galeria-indicator">Convidado 1/1</span>
+				<button type="button" class="btn-sm-outline" id="presencial-galeria-next" aria-label="Próximo convidado">›</button>
+			</header>
+			<div class="vc-galeria__body">
+				<div class="portaria-presencial-field" id="presencial-convidado-nome-wrap">
+					{% call field(label="Nome completo *") %}
+						{{ input(attrs={"id": "presencial-convidado-nome", "required": "required", "autocomplete": "off", "placeholder": "Ex.: João Souza"}) }}
+					{% endcall %}
+					<p class="text-xs text-destructive portaria-presencial-erro" id="presencial-convidado-nome-erro" hidden></p>
+				</div>
+			</div>
+		</div>
+		{% endcall %}
+
+		<div class="portaria-presencial-total">
+			<span>Valor total</span>
+			<strong id="presencial-valor-total">R$ 0,00</strong>
+		</div>
+	</section>
+	<footer>
+		<button type="button" class="btn-outline" onclick="this.closest('dialog').close()">Cancelar</button>
+		<button type="button" class="btn-primary" id="btn-presencial-confirmar">
+			{{ lucide_icon("check", size="sm") }}
+			<span>Pagamento realizado</span>
+		</button>
 	</footer>
 </div>
 </dialog>

--- a/gris/www/festas/portaria.js
+++ b/gris/www/festas/portaria.js
@@ -83,6 +83,53 @@
 		return "Erro de servidor.";
 	}
 
+	// Confirmação custom via o dialog #confirm-dialog presente em portaria.html.
+	// Mantém o look-and-feel do Basecoat (botão danger) sem depender do helper
+	// global do festa.js, que não é carregado nesta página.
+	function confirmDialog(opts) {
+		opts = opts || {};
+		return new Promise(function (resolve) {
+			const dlg = document.getElementById("confirm-dialog");
+			if (!dlg || typeof dlg.showModal !== "function") {
+				resolve(window.confirm(opts.message || opts.title || "Confirmar?"));
+				return;
+			}
+			const titleEl = dlg.querySelector("header h2");
+			const messageEl = dlg.querySelector("#confirm-dialog-message");
+			const okBtn = dlg.querySelector("#confirm-dialog-ok");
+			const cancelBtn = dlg.querySelector("#confirm-dialog-cancel");
+			if (titleEl) titleEl.textContent = opts.title || "Confirmar ação";
+			if (messageEl) messageEl.textContent = opts.message || "Tem certeza?";
+			if (okBtn) {
+				okBtn.textContent = opts.confirmLabel || "Confirmar";
+				okBtn.className = opts.variant === "primary" ? "btn-primary" : "btn-destructive";
+			}
+			function cleanup() {
+				if (okBtn) okBtn.removeEventListener("click", onOk);
+				if (cancelBtn) cancelBtn.removeEventListener("click", onCancel);
+				dlg.removeEventListener("close", onClose);
+			}
+			function onOk() {
+				cleanup();
+				dlg.close("confirm");
+				resolve(true);
+			}
+			function onCancel() {
+				cleanup();
+				dlg.close("cancel");
+				resolve(false);
+			}
+			function onClose() {
+				cleanup();
+				if (dlg.returnValue !== "confirm") resolve(false);
+			}
+			if (okBtn) okBtn.addEventListener("click", onOk);
+			if (cancelBtn) cancelBtn.addEventListener("click", onCancel);
+			dlg.addEventListener("close", onClose);
+			dlg.showModal();
+		});
+	}
+
 	// Bypass da frappe.call do portal: ela roda process_response no .always,
 	// que loga data.exc no console.error e mostra msgprint, sem permitir
 	// opt-out. Usamos fetch direto para ter controle total do fluxo de erro
@@ -603,6 +650,9 @@
 		set("portaria-det-nome", entrada.nome_convidado);
 		set("portaria-det-email", entrada.email);
 		set("portaria-det-telefone", entrada.telefone);
+		set("portaria-det-pagador-nome", entrada.nome_pagador);
+		set("portaria-det-pagador-email", entrada.email_pagador);
+		set("portaria-det-pagador-telefone", entrada.telefone_pagador);
 		set("portaria-det-codigo", entrada.codigo);
 		set("portaria-det-hora", entrada.hora_entrada ? fmtData(entrada.hora_entrada) : "—");
 		set("portaria-det-por", entrada.registrado_por);
@@ -622,7 +672,53 @@
 			statusEl.appendChild(badge);
 		}
 
+		// "Entrada Manual" só faz sentido para quem ainda não entrou.
+		const btnManual = document.getElementById("btn-portaria-det-entrada-manual");
+		if (btnManual) btnManual.hidden = !!entrada.ja_entrou;
+
 		if (dlg && typeof dlg.showModal === "function") dlg.showModal();
+	}
+
+	function confirmarEntradaManual() {
+		if (!entradaDetalhesAtual) return;
+		const entrada = entradaDetalhesAtual;
+		const nome = entrada.nome_convidado || "este convidado";
+		confirmDialog({
+			title: "Confirmar entrada manual?",
+			message: "Esta ação irá confirmar a entrada de " + nome
+				+ " mesmo sem apresentar o QR code. Use apenas quando o convidado realmente comprou o convite.",
+			confirmLabel: "Confirmar entrada",
+			variant: "destructive",
+		}).then(function (ok) {
+			if (!ok) return;
+			const btn = document.getElementById("btn-portaria-det-entrada-manual");
+			if (btn) btn.disabled = true;
+			api("gris.api.festas.portaria.marcar_entrada_manual", {
+				festa: festaAtual,
+				codigo: entrada.codigo,
+			})
+				.then(function (resp) {
+					if (!resp || resp.valido === false) {
+						toast("Convidado não encontrado para esta festa.", "error");
+						return;
+					}
+					if (resp.ja_entrou_antes) {
+						toast("Entrada já estava confirmada.", "info");
+					} else {
+						toast("Entrada manual confirmada: " + (resp.nome_convidado || ""), "success");
+					}
+					const dlgDet = document.getElementById("dlg-portaria-detalhes");
+					if (dlgDet && dlgDet.open) dlgDet.close();
+					carregarLista();
+					if (chartPizza) carregarAcompanhamento();
+				})
+				.catch(function (err) {
+					toast(err.message || "Falha ao confirmar entrada manual.", "error");
+				})
+				.finally(function () {
+					if (btn) btn.disabled = false;
+				});
+		});
 	}
 
 	function abrirEditar(entrada) {
@@ -1324,6 +1420,11 @@
 				if (!entradaDetalhesAtual) return;
 				confirmarReenvio(entradaDetalhesAtual);
 			});
+		}
+
+		const btnDetEntradaManual = document.getElementById("btn-portaria-det-entrada-manual");
+		if (btnDetEntradaManual) {
+			btnDetEntradaManual.addEventListener("click", confirmarEntradaManual);
 		}
 
 		const filtroNome = document.getElementById("portaria-filtro-nome");

--- a/gris/www/festas/portaria.js
+++ b/gris/www/festas/portaria.js
@@ -16,9 +16,20 @@
 	let jsqrLoading = null;
 	let chartPizza = null;
 	let chartLinha = null;
+	let chartOrigem = null;
 	let linhaModo = "acumulado";
 	let echartsLoading = null;
 	let acompanhamentoTimer = null;
+
+	// ─── Estado do fluxo "Vender na porta" presencial ──────────────────────
+	const presencialState = {
+		precoUnitario: 0,
+		quantidade: 1,
+		meioPagamento: null, // "Dinheiro" | "Cartão"
+		convidados: [{ nome: "" }],
+		convidadoIdx: 0,
+		submetendo: false,
+	};
 
 	const TAB_CONVIDADOS_IDX = 1;
 	const TAB_ACOMPANHAMENTO_IDX = 2;
@@ -675,7 +686,22 @@
 			toast("Selecione uma festa primeiro.", "error");
 			return;
 		}
-		const dlg = document.getElementById("dlg-portaria-vender");
+		const dlg = document.getElementById("dlg-portaria-vender-modo");
+		if (dlg && typeof dlg.showModal === "function") dlg.showModal();
+	}
+
+	function escolherModoVenda(modo) {
+		const dlgModo = document.getElementById("dlg-portaria-vender-modo");
+		if (dlgModo && dlgModo.open) dlgModo.close();
+		if (modo === "link") {
+			abrirVenderLink();
+		} else if (modo === "presencial") {
+			abrirVenderPresencial();
+		}
+	}
+
+	function abrirVenderLink() {
+		const dlg = document.getElementById("dlg-portaria-vender-link");
 		const urlEl = document.getElementById("portaria-vender-qr-url");
 		if (urlEl) urlEl.textContent = "";
 		const img = document.getElementById("portaria-vender-qr");
@@ -693,25 +719,360 @@
 			});
 	}
 
+	function abrirVenderPresencial() {
+		api("gris.api.festas.portaria.get_url_venda_porta", { festa: festaAtual })
+			.then(function (resp) {
+				presencialState.precoUnitario = Number(resp.preco || 0);
+				presencialState.quantidade = 1;
+				presencialState.meioPagamento = null;
+				presencialState.convidados = [{ nome: "" }];
+				presencialState.convidadoIdx = 0;
+				presencialState.submetendo = false;
+				limparErrosPresencial();
+				renderPresencialUI();
+				const dlg = document.getElementById("dlg-portaria-vender-presencial");
+				if (dlg && typeof dlg.showModal === "function") dlg.showModal();
+			})
+			.catch(function (err) {
+				toast(err.message || "Não foi possível preparar a venda.", "error");
+			});
+	}
+
+	function lerTelefonePresencialDOM() {
+		const wrap = document.getElementById("presencial-pagador-telefone");
+		if (!wrap) return "";
+		const hidden = wrap.querySelector("[data-phone-input-value]");
+		if (hidden && hidden.value) return hidden.value.trim();
+		const num = wrap.querySelector("[data-phone-input-number]");
+		const raw = num ? num.value.replace(/\D/g, "") : "";
+		return raw;
+	}
+
+	function nomeCompleto(valor) {
+		const partes = String(valor || "").trim().split(/\s+/).filter(Boolean);
+		return partes.length >= 2;
+	}
+
+	function marcarErro(wrapId, erroId, mensagem) {
+		const wrap = document.getElementById(wrapId);
+		if (wrap) wrap.classList.add("portaria-presencial-field--erro");
+		if (erroId) {
+			const el = document.getElementById(erroId);
+			if (el) {
+				el.textContent = mensagem || "";
+				el.hidden = !mensagem;
+			}
+		}
+	}
+
+	function limparErro(wrapId, erroId) {
+		const wrap = document.getElementById(wrapId);
+		if (wrap) wrap.classList.remove("portaria-presencial-field--erro");
+		if (erroId) {
+			const el = document.getElementById(erroId);
+			if (el) {
+				el.textContent = "";
+				el.hidden = true;
+			}
+		}
+	}
+
+	function limparErrosPresencial() {
+		[
+			["presencial-pagador-nome-wrap", "presencial-pagador-nome-erro"],
+			["presencial-pagador-email-wrap", "presencial-pagador-email-erro"],
+			["presencial-pagador-telefone-wrap", "presencial-pagador-telefone-erro"],
+			["presencial-convidado-nome-wrap", "presencial-convidado-nome-erro"],
+			["presencial-meio-wrap", "presencial-meio-erro"],
+		].forEach(function (par) {
+			limparErro(par[0], par[1]);
+		});
+	}
+
+	function ajustarQuantidadePresencial(delta) {
+		salvarConvidadoAtualPresencial();
+		const nova = Math.max(1, presencialState.quantidade + delta);
+		if (nova === presencialState.quantidade) return;
+		while (presencialState.convidados.length < nova) {
+			presencialState.convidados.push({ nome: "" });
+		}
+		if (presencialState.convidados.length > nova) {
+			presencialState.convidados = presencialState.convidados.slice(0, nova);
+		}
+		presencialState.quantidade = nova;
+		if (presencialState.convidadoIdx >= nova) {
+			presencialState.convidadoIdx = nova - 1;
+		}
+		renderPresencialUI();
+	}
+
+	function definirQuantidadePresencial(valor) {
+		salvarConvidadoAtualPresencial();
+		let nova = parseInt(valor, 10);
+		if (!Number.isFinite(nova) || nova < 1) nova = 1;
+		while (presencialState.convidados.length < nova) {
+			presencialState.convidados.push({ nome: "" });
+		}
+		if (presencialState.convidados.length > nova) {
+			presencialState.convidados = presencialState.convidados.slice(0, nova);
+		}
+		presencialState.quantidade = nova;
+		if (presencialState.convidadoIdx >= nova) {
+			presencialState.convidadoIdx = nova - 1;
+		}
+		renderPresencialUI();
+	}
+
+	function selecionarMeioPagamentoPresencial(meio) {
+		presencialState.meioPagamento = meio;
+		const cards = document.querySelectorAll(".portaria-meio-card");
+		cards.forEach(function (card) {
+			const ativo = card.getAttribute("data-meio") === meio;
+			card.setAttribute("aria-checked", ativo ? "true" : "false");
+			card.classList.toggle("portaria-meio-card--ativo", ativo);
+		});
+	}
+
+	function salvarConvidadoAtualPresencial() {
+		const input = document.getElementById("presencial-convidado-nome");
+		if (!input) return;
+		const idx = presencialState.convidadoIdx;
+		if (!presencialState.convidados[idx]) {
+			presencialState.convidados[idx] = { nome: "" };
+		}
+		presencialState.convidados[idx].nome = (input.value || "").trim();
+	}
+
+	function renderConvidadoAtualPresencial() {
+		const idx = presencialState.convidadoIdx;
+		const total = presencialState.quantidade;
+		const indicator = document.getElementById("presencial-galeria-indicator");
+		if (indicator) {
+			indicator.textContent = "Convidado " + (idx + 1) + "/" + total;
+		}
+		const input = document.getElementById("presencial-convidado-nome");
+		if (input) {
+			input.value = (presencialState.convidados[idx] || {}).nome || "";
+		}
+		const prev = document.getElementById("presencial-galeria-prev");
+		const next = document.getElementById("presencial-galeria-next");
+		if (prev) prev.disabled = idx <= 0;
+		if (next) next.disabled = idx >= total - 1;
+	}
+
+	function navegarConvidadoPresencial(delta) {
+		salvarConvidadoAtualPresencial();
+		const novoIdx = presencialState.convidadoIdx + delta;
+		if (novoIdx < 0 || novoIdx >= presencialState.quantidade) return;
+		presencialState.convidadoIdx = novoIdx;
+		limparErro("presencial-convidado-nome-wrap", "presencial-convidado-nome-erro");
+		renderConvidadoAtualPresencial();
+	}
+
+	function formatarMoeda(valor) {
+		const numero = Number(valor || 0);
+		return numero.toLocaleString("pt-BR", {
+			style: "currency",
+			currency: "BRL",
+		});
+	}
+
+	function atualizarTotalPresencial() {
+		const total = (presencialState.precoUnitario || 0) * (presencialState.quantidade || 0);
+		const totalEl = document.getElementById("presencial-valor-total");
+		if (totalEl) totalEl.textContent = formatarMoeda(total);
+		const unitEl = document.getElementById("presencial-preco-unitario");
+		if (unitEl) unitEl.textContent = formatarMoeda(presencialState.precoUnitario);
+	}
+
+	function renderPresencialUI() {
+		const qtdInput = document.getElementById("presencial-quantidade");
+		if (qtdInput) qtdInput.value = String(presencialState.quantidade);
+		const nomeInput = document.getElementById("presencial-pagador-nome");
+		const emailInput = document.getElementById("presencial-pagador-email");
+		const telInput = document.getElementById("presencial-pagador-telefone");
+		// Limpa apenas quando o dialog acabou de abrir (quantidade=1 e sem convidado preenchido)
+		if (
+			presencialState.quantidade === 1 &&
+			!(presencialState.convidados[0] && presencialState.convidados[0].nome) &&
+			!presencialState.meioPagamento &&
+			!presencialState.submetendo
+		) {
+			if (nomeInput) nomeInput.value = "";
+			if (emailInput) emailInput.value = "";
+			if (telInput) telInput.value = "";
+		}
+		selecionarMeioPagamentoPresencial(presencialState.meioPagamento);
+		atualizarTotalPresencial();
+		renderConvidadoAtualPresencial();
+	}
+
+	function confirmarVendaPresencial() {
+		if (presencialState.submetendo) return;
+		salvarConvidadoAtualPresencial();
+		limparErrosPresencial();
+
+		const nome = ((document.getElementById("presencial-pagador-nome") || {}).value || "").trim();
+		const email = ((document.getElementById("presencial-pagador-email") || {}).value || "").trim();
+		const telefone = lerTelefonePresencialDOM();
+
+		const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+		let primeiroErro = null;
+		let erros = 0;
+
+		if (!nome) {
+			marcarErro("presencial-pagador-nome-wrap", "presencial-pagador-nome-erro", "Informe o nome do pagador.");
+			primeiroErro = primeiroErro || "presencial-pagador-nome";
+			erros += 1;
+		} else if (!nomeCompleto(nome)) {
+			marcarErro(
+				"presencial-pagador-nome-wrap",
+				"presencial-pagador-nome-erro",
+				"Informe o nome completo (nome e sobrenome).",
+			);
+			primeiroErro = primeiroErro || "presencial-pagador-nome";
+			erros += 1;
+		}
+
+		if (email && !EMAIL_RE.test(email)) {
+			marcarErro("presencial-pagador-email-wrap", "presencial-pagador-email-erro", "E-mail inválido.");
+			primeiroErro = primeiroErro || "presencial-pagador-email";
+			erros += 1;
+		}
+
+		if (telefone && telefone.replace(/\D/g, "").length < 10) {
+			marcarErro(
+				"presencial-pagador-telefone-wrap",
+				"presencial-pagador-telefone-erro",
+				"Telefone inválido.",
+			);
+			primeiroErro = primeiroErro || "presencial-pagador-telefone-number";
+			erros += 1;
+		}
+
+		if (!presencialState.meioPagamento) {
+			marcarErro(
+				"presencial-meio-wrap",
+				"presencial-meio-erro",
+				"Escolha a forma de pagamento (Dinheiro ou Cartão).",
+			);
+			erros += 1;
+		}
+
+		let convidadoErroIdx = -1;
+		let convidadoErroMsg = "";
+		for (let i = 0; i < presencialState.quantidade; i += 1) {
+			const c = presencialState.convidados[i] || { nome: "" };
+			if (!c.nome) {
+				convidadoErroIdx = i;
+				convidadoErroMsg = "Informe o nome do convidado.";
+				break;
+			}
+			if (!nomeCompleto(c.nome)) {
+				convidadoErroIdx = i;
+				convidadoErroMsg = "Informe o nome completo (nome e sobrenome).";
+				break;
+			}
+		}
+		if (convidadoErroIdx >= 0) {
+			presencialState.convidadoIdx = convidadoErroIdx;
+			renderConvidadoAtualPresencial();
+			marcarErro(
+				"presencial-convidado-nome-wrap",
+				"presencial-convidado-nome-erro",
+				convidadoErroMsg,
+			);
+			primeiroErro = primeiroErro || "presencial-convidado-nome";
+			erros += 1;
+		}
+
+		if (erros > 0) {
+			toast("Revise os campos destacados.", "error");
+			if (primeiroErro) {
+				const focusEl = document.getElementById(primeiroErro);
+				if (focusEl && typeof focusEl.focus === "function") focusEl.focus();
+			}
+			return;
+		}
+
+		presencialState.submetendo = true;
+		const btn = document.getElementById("btn-presencial-confirmar");
+		if (btn) btn.disabled = true;
+
+		api("gris.api.festas.portaria.criar_convite_presencial", {
+			festa: festaAtual,
+			pagador: { nome: nome, email: email, telefone: telefone },
+			quantidade: presencialState.quantidade,
+			meio_pagamento: presencialState.meioPagamento,
+			convidados: presencialState.convidados.slice(0, presencialState.quantidade).map(function (c) {
+				return { nome: c.nome };
+			}),
+		})
+			.then(function (resp) {
+				toast(
+					"Venda registrada (" + formatarMoeda(resp.valor_total) + ", " + (resp.meio_pagamento || "") + ").",
+					"success"
+				);
+				const dlg = document.getElementById("dlg-portaria-vender-presencial");
+				if (dlg && dlg.open) dlg.close();
+				carregarLista();
+				if (tabAtiva() === TAB_ACOMPANHAMENTO_IDX) carregarAcompanhamento();
+			})
+			.catch(function (err) {
+				toast(extractServerMessage(err) || "Falha ao registrar venda presencial.", "error");
+			})
+			.finally(function () {
+				presencialState.submetendo = false;
+				if (btn) btn.disabled = false;
+			});
+	}
+
 	// ─── Acompanhamento (gráficos) ─────────────────────────────────────────
 
 	// Paleta acessível (Wong, daltonismo-friendly)
 	const COR_ENTROU = "#009E73";
 	const COR_NAO_ENTROU = "#D55E00";
 	const COR_LINHA = "#0072B2";
+	const COR_PORTARIA = "#0072B2";
+	const COR_COMPRA_PREVIA = "#56B4E9";
+	const COR_COMPRA_PORTARIA = "#E69F00";
 
 	function carregarAcompanhamento() {
 		if (!festaAtual) return Promise.resolve();
 		return api("gris.api.festas.portaria.get_acompanhamento", { festa: festaAtual })
 			.then(function (resp) {
 				return ensureECharts().then(function () {
+					renderIndicadorTotal(resp.pizza);
 					renderPizza(resp.pizza);
+					renderOrigem(resp.origem_entradas);
 					renderLinha(resp.linha);
 				});
 			})
 			.catch(function (err) {
 				toast(err.message || "Falha ao carregar gráficos.", "error");
 			});
+	}
+
+	function renderIndicadorTotal(pizza) {
+		const el = document.getElementById("portaria-indicador-total-valor");
+		if (el) {
+			const total = Number((pizza && pizza.total_entrou) || 0);
+			el.textContent = String(total);
+		}
+		const extra = document.getElementById("portaria-indicador-total-extra");
+		if (extra) {
+			const previa = Number((pizza && pizza.entrou) || 0);
+			const totalEntrou = Number((pizza && pizza.total_entrou) || 0);
+			if (totalEntrou > 0) {
+				const pct = Math.round((previa / totalEntrou) * 1000) / 10;
+				extra.textContent = pct.toLocaleString("pt-BR", {
+					minimumFractionDigits: pct % 1 === 0 ? 0 : 1,
+					maximumFractionDigits: 1,
+				}) + "% de compras prévias";
+			} else {
+				extra.textContent = "Sem entradas registradas";
+			}
+		}
 	}
 
 	function renderPizza(pizza) {
@@ -726,15 +1087,17 @@
 		const total = Number((pizza && pizza.total) || 0);
 		const entrou = Number((pizza && pizza.entrou) || 0);
 		const naoEntrou = Number((pizza && pizza.nao_entrou) || 0);
+		const comprouPortaria = Number((pizza && pizza.comprou_portaria) || 0);
 		chartPizza.setOption({
 			tooltip: { trigger: "item" },
-			legend: { bottom: 0 },
-			color: [COR_ENTROU, COR_NAO_ENTROU],
+			legend: { bottom: 0, padding: [16, 0, 0, 0] },
+			color: [COR_ENTROU, COR_NAO_ENTROU, COR_PORTARIA],
 			series: [
 				{
 					name: "Entradas",
 					type: "pie",
-					radius: ["45%", "70%"],
+					radius: ["40%", "62%"],
+					center: ["50%", "42%"],
 					avoidLabelOverlap: true,
 					label: {
 						show: true,
@@ -745,6 +1108,7 @@
 					data: [
 						{ value: entrou, name: "Entrou" },
 						{ value: naoEntrou, name: "Não entrou" },
+						{ value: comprouPortaria, name: "Comprou na Portaria" },
 					],
 				},
 			],
@@ -755,6 +1119,56 @@
 					top: "middle",
 					style: {
 						text: "Sem dados ainda",
+						fill: "#888",
+						font: "14px sans-serif",
+					},
+				},
+			] : undefined,
+		});
+	}
+
+	function renderOrigem(origem) {
+		const el = document.getElementById("chart-portaria-origem");
+		if (!el) return;
+		if (!chartOrigem) {
+			chartOrigem = window.echarts.init(el);
+			window.addEventListener("resize", function () {
+				if (chartOrigem) chartOrigem.resize();
+			});
+		}
+		const previa = Number((origem && origem.compra_previa) || 0);
+		const portaria = Number((origem && origem.compra_portaria) || 0);
+		const total = previa + portaria;
+		chartOrigem.setOption({
+			tooltip: { trigger: "item" },
+			legend: { bottom: 0, padding: [16, 0, 0, 0] },
+			color: [COR_COMPRA_PREVIA, COR_COMPRA_PORTARIA],
+			series: [
+				{
+					name: "Origem",
+					type: "pie",
+					radius: ["40%", "62%"],
+					center: ["50%", "42%"],
+					avoidLabelOverlap: true,
+					label: {
+						show: true,
+						formatter: function (p) {
+							return p.name + "\n" + p.value + " (" + p.percent + "%)";
+						},
+					},
+					data: [
+						{ value: previa, name: "Compra Prévia" },
+						{ value: portaria, name: "Compra na Portaria" },
+					],
+				},
+			],
+			graphic: total === 0 ? [
+				{
+					type: "text",
+					left: "center",
+					top: "middle",
+					style: {
+						text: "Sem entradas registradas",
 						fill: "#888",
 						font: "14px sans-serif",
 					},
@@ -944,6 +1358,64 @@
 		// Fechar dialog do scanner solta a câmera.
 		const dlgScan = document.getElementById("dlg-portaria-scan");
 		if (dlgScan) dlgScan.addEventListener("close", function () { pararCamera(); });
+
+		// ─── Fluxo "Vender na porta" ────────────────────────────────────────
+		const btnModoLink = document.getElementById("btn-portaria-modo-link");
+		if (btnModoLink) btnModoLink.addEventListener("click", function () { escolherModoVenda("link"); });
+		const btnModoPresencial = document.getElementById("btn-portaria-modo-presencial");
+		if (btnModoPresencial) btnModoPresencial.addEventListener("click", function () { escolherModoVenda("presencial"); });
+
+		const btnQtdMenos = document.getElementById("btn-presencial-quantidade-menos");
+		if (btnQtdMenos) btnQtdMenos.addEventListener("click", function () { ajustarQuantidadePresencial(-1); });
+		const btnQtdMais = document.getElementById("btn-presencial-quantidade-mais");
+		if (btnQtdMais) btnQtdMais.addEventListener("click", function () { ajustarQuantidadePresencial(1); });
+		const qtdInput = document.getElementById("presencial-quantidade");
+		if (qtdInput) {
+			qtdInput.addEventListener("change", function () { definirQuantidadePresencial(qtdInput.value); });
+			qtdInput.addEventListener("blur", function () { definirQuantidadePresencial(qtdInput.value); });
+		}
+
+		const btnMeioDin = document.getElementById("btn-presencial-meio-dinheiro");
+		if (btnMeioDin) btnMeioDin.addEventListener("click", function () {
+			selecionarMeioPagamentoPresencial("Dinheiro");
+			limparErro("presencial-meio-wrap", "presencial-meio-erro");
+		});
+		const btnMeioCartao = document.getElementById("btn-presencial-meio-cartao");
+		if (btnMeioCartao) btnMeioCartao.addEventListener("click", function () {
+			selecionarMeioPagamentoPresencial("Cartão");
+			limparErro("presencial-meio-wrap", "presencial-meio-erro");
+		});
+
+		const pagadorNomeInput = document.getElementById("presencial-pagador-nome");
+		if (pagadorNomeInput) pagadorNomeInput.addEventListener("input", function () {
+			limparErro("presencial-pagador-nome-wrap", "presencial-pagador-nome-erro");
+		});
+		const pagadorEmailInput = document.getElementById("presencial-pagador-email");
+		if (pagadorEmailInput) pagadorEmailInput.addEventListener("input", function () {
+			limparErro("presencial-pagador-email-wrap", "presencial-pagador-email-erro");
+		});
+		const pagadorTelInput = document.getElementById("presencial-pagador-telefone-number");
+		if (pagadorTelInput) pagadorTelInput.addEventListener("input", function () {
+			limparErro("presencial-pagador-telefone-wrap", "presencial-pagador-telefone-erro");
+		});
+
+		const galPrev = document.getElementById("presencial-galeria-prev");
+		if (galPrev) galPrev.addEventListener("click", function () { navegarConvidadoPresencial(-1); });
+		const galNext = document.getElementById("presencial-galeria-next");
+		if (galNext) galNext.addEventListener("click", function () { navegarConvidadoPresencial(1); });
+		const nomeConv = document.getElementById("presencial-convidado-nome");
+		if (nomeConv) {
+			nomeConv.addEventListener("blur", salvarConvidadoAtualPresencial);
+			nomeConv.addEventListener("input", function () {
+				const idx = presencialState.convidadoIdx;
+				if (!presencialState.convidados[idx]) presencialState.convidados[idx] = { nome: "" };
+				presencialState.convidados[idx].nome = (nomeConv.value || "").trim();
+				limparErro("presencial-convidado-nome-wrap", "presencial-convidado-nome-erro");
+			});
+		}
+
+		const btnConfirmarPresencial = document.getElementById("btn-presencial-confirmar");
+		if (btnConfirmarPresencial) btnConfirmarPresencial.addEventListener("click", confirmarVendaPresencial);
 	}
 
 	document.addEventListener("DOMContentLoaded", function () {

--- a/gris/www/festas/venda_convite.css
+++ b/gris/www/festas/venda_convite.css
@@ -420,6 +420,47 @@
 	margin-bottom: 0.5rem;
 }
 
+/* ─── Lista de nomes (pagador recebe todos os QR codes) ──────────────── */
+
+.vc-nomes-pagador-recebe {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+	border: 1px solid var(--border);
+	border-radius: var(--radius);
+	padding: 1rem;
+	background: var(--card);
+	margin-top: 1rem;
+}
+
+.vc-nomes-pagador-recebe__acoes {
+	display: flex;
+	justify-content: flex-end;
+}
+
+.vc-nomes-pagador-recebe__lista {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+}
+
+.vc-nomes-pagador-recebe__item {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+}
+
+.vc-nomes-pagador-recebe__label {
+	font-size: 0.875rem;
+	font-weight: 500;
+	color: var(--foreground);
+}
+
+.vc-nomes-pagador-recebe__tipo {
+	color: var(--muted-foreground);
+	font-weight: 400;
+}
+
 /* ─── Revisão (final) ────────────────────────────────────────────────── */
 
 .vc-revisao-bloco {

--- a/gris/www/festas/venda_convite.html
+++ b/gris/www/festas/venda_convite.html
@@ -169,7 +169,7 @@ window._vendaConvite = {
 
 	</p>
 	{% call field(label="Enviar todos para o meu e-mail") %}
-		{{ switch(name="vc-pagador-recebe", checked=true, attrs={"id": "vc-pagador-recebe"}) }}
+		{{ switch(name="vc-pagador-recebe", checked=false, attrs={"id": "vc-pagador-recebe"}) }}
 	{% endcall %}
 
 	<div id="vc-galeria" class="vc-galeria" hidden>
@@ -199,6 +199,16 @@ window._vendaConvite = {
 				{% endcall %}
 			</div>
 		</div>
+	</div>
+
+	<div id="vc-nomes-pagador-recebe" class="vc-nomes-pagador-recebe" hidden>
+		<p class="text-sm text-muted-foreground">
+			Informe o nome de cada convidado. Os QR codes serão enviados todos para o seu e-mail.
+		</p>
+		<div class="vc-nomes-pagador-recebe__acoes">
+			<button type="button" class="btn-outline" id="vc-usar-dados-pagador" hidden>Usar meus dados</button>
+		</div>
+		<div id="vc-nomes-pagador-recebe-lista" class="vc-nomes-pagador-recebe__lista"></div>
 	</div>
 	{% endcall %}
 

--- a/gris/www/festas/venda_convite.js
+++ b/gris/www/festas/venda_convite.js
@@ -12,7 +12,7 @@
 	let doarFlag = false;
 	let doacaoValor = 10;
 	let pagador = { nome: "", email: "", telefone: "" };
-	let pagadorRecebe = true;
+	let pagadorRecebe = false;
 	let convidados = []; // [{nome, email, telefone, tipo_convite}]
 	let convidadoIdx = 0;
 	let pedidoNome = null;
@@ -473,20 +473,46 @@
 		if (convidadoIdx >= convidados.length) convidadoIdx = 0;
 	}
 
-	function aplicarPagadorAosConvidados() {
-		convidados.forEach(function (c) {
-			c.nome = pagador.nome;
-			c.email = pagador.email;
-			c.telefone = pagador.telefone;
-		});
-	}
-
 	function renderConvidados() {
 		expandirConvidados();
 		const galeria = document.getElementById("vc-galeria");
-		if (galeria) galeria.hidden = pagadorRecebe || convidados.length === 0;
-		renderGaleriaAtual();
+		const nomesBox = document.getElementById("vc-nomes-pagador-recebe");
+		const temConvidado = convidados.length > 0;
+		if (galeria) galeria.hidden = pagadorRecebe || !temConvidado;
+		if (nomesBox) nomesBox.hidden = !pagadorRecebe || !temConvidado;
+		if (pagadorRecebe) {
+			renderNomesPagadorRecebe();
+		} else {
+			renderGaleriaAtual();
+		}
 		atualizarBotaoConvidadosContinuar();
+	}
+
+	function renderNomesPagadorRecebe() {
+		const lista = document.getElementById("vc-nomes-pagador-recebe-lista");
+		const btnUsar = document.getElementById("vc-usar-dados-pagador");
+		if (btnUsar) btnUsar.hidden = convidados.length !== 1;
+		if (!lista) return;
+		lista.innerHTML = convidados.map(function (c, idx) {
+			const tipo = c.tipo_convite ? ' <span class="vc-nomes-pagador-recebe__tipo">· ' + escapeHtml(c.tipo_convite) + "</span>" : "";
+			const valor = escapeHtml(c.nome || "");
+			const inputId = "vc-pr-nome-" + idx;
+			return '<div class="vc-nomes-pagador-recebe__item">'
+				+ '<label class="vc-nomes-pagador-recebe__label" for="' + inputId + '">'
+				+ "Convite " + (idx + 1) + tipo
+				+ "</label>"
+				+ '<input class="input" type="text" id="' + inputId + '" data-vc-pr-idx="' + idx + '"'
+				+ ' value="' + valor + '" required autocomplete="name" placeholder="Nome do convidado">'
+				+ "</div>";
+		}).join("");
+		const inputs = lista.querySelectorAll("input[data-vc-pr-idx]");
+		inputs.forEach(function (inp) {
+			inp.addEventListener("input", function () {
+				const idx = parseInt(inp.getAttribute("data-vc-pr-idx"), 10);
+				if (convidados[idx]) convidados[idx].nome = inp.value.trim();
+				atualizarBotaoConvidadosContinuar();
+			});
+		});
 	}
 
 	function lerTelefoneConvidadoDOM() {
@@ -544,7 +570,13 @@
 	function atualizarBotaoConvidadosContinuar() {
 		const btn = document.getElementById("btn-convidados-continuar");
 		if (!btn) return;
-		if (pagadorRecebe) { btn.disabled = false; return; }
+		if (pagadorRecebe) {
+			const valido = convidados.length > 0 && convidados.every(function (c) {
+				return c.nome && c.nome.trim().length > 0;
+			});
+			btn.disabled = !valido;
+			return;
+		}
 		const valido = convidados.length > 0 && convidados.every(function (c) {
 			return c.nome && emailValido(c.email);
 		});
@@ -620,6 +652,19 @@
 				numConv.addEventListener("change", onTelConvChange);
 			}
 		}
+
+		// Botão "Usar meus dados" (modo pagador-recebe + 1 convite): preenche
+		// o único campo de nome com o nome do pagador.
+		const btnUsar = document.getElementById("vc-usar-dados-pagador");
+		if (btnUsar) {
+			btnUsar.addEventListener("click", function () {
+				sincronizarPagador();
+				if (!pagador.nome || convidados.length !== 1) return;
+				convidados[0].nome = pagador.nome;
+				renderNomesPagadorRecebe();
+				atualizarBotaoConvidadosContinuar();
+			});
+		}
 	}
 
 	// ─── Aba Revisão (final) ────────────────────────────────────────────────
@@ -639,13 +684,13 @@
 				ul.innerHTML = '<li class="text-sm text-muted-foreground">Nenhum convite no pedido.</li>';
 			} else {
 				ul.innerHTML = convidados.map(function (c, idx) {
-					const destino = pagadorRecebe
-						? '<span class="text-sm text-muted-foreground">QR code para o pagador</span>'
-						: "<strong>" + escapeHtml(c.nome || "Convidado " + (idx + 1)) + "</strong>" +
-						  ' <span class="text-sm text-muted-foreground">· ' + escapeHtml(c.email || "—") + "</span>";
+					const nomeHtml = "<strong>" + escapeHtml(c.nome || "Convidado " + (idx + 1)) + "</strong>";
+					const detalhe = pagadorRecebe
+						? ' <span class="text-sm text-muted-foreground">· QR no e-mail do pagador</span>'
+						: ' <span class="text-sm text-muted-foreground">· ' + escapeHtml(c.email || "—") + "</span>";
 					return '<li class="vc-revisao-convite">' +
 						'<span class="vc-revisao-convite__tipo">' + escapeHtml(c.tipo_convite || "Convite") + "</span>" +
-						'<span class="vc-revisao-convite__destino">' + destino + "</span>" +
+						'<span class="vc-revisao-convite__destino">' + nomeHtml + detalhe + "</span>" +
 						"</li>";
 				}).join("");
 			}
@@ -733,7 +778,6 @@
 		}
 		sincronizarPagador();
 		if (!pagadorRecebe) salvarConvidadoAtual();
-		if (pagadorRecebe) aplicarPagadorAosConvidados();
 
 		const btn = document.getElementById("btn-revisao-finalizar");
 		if (btn) btn.disabled = true;
@@ -745,7 +789,7 @@
 			pagador: JSON.stringify(pagador),
 			itens: JSON.stringify(carrinhoComoArray()),
 			doacao_valor: doarFlag ? doacaoValor : 0,
-			convidados: JSON.stringify(pagadorRecebe ? [] : convidados),
+			convidados: JSON.stringify(convidados),
 			pagador_recebe_qr_codes: pagadorRecebe ? 1 : 0,
 		})
 			.then(function (resp) {


### PR DESCRIPTION
This pull request introduces support for in-person (presencial) ticket sales at the event entrance, along with several improvements to data validation and reporting. The main changes include new endpoints and backend logic for registering presencial sales, adjustments to the data model to track payment method and presencial status, and updates to reporting and validation to correctly handle these new flows.

**Presencial ticket sales and entry tracking:**

* Added the `criar_convite_presencial` endpoint to allow authorized users to register in-person ticket sales (cash/card), including robust validation for payer and guest data, and automatic marking of attendance. (`gris/api/festas/portaria.py` [gris/api/festas/portaria.pyR504-R652](diffhunk://#diff-85c06ecaf8360f25941891603672f161bd88be28e9c52a27f153ca9b96800e1cR504-R652))
* Updated the data model to include `presencial` (checkbox) and `meio_pagamento` (select field) in `Convite Festa`, with logic to enforce valid combinations and make payer email/phone optional for presencial sales. (`gris/festas/doctype/convite_festa/convite_festa.json` [[1]](diffhunk://#diff-3e35daebe129ff7baafae0a62ba39000acddc0755b78f4a535681db3b72abd57R17-R18) [[2]](diffhunk://#diff-3e35daebe129ff7baafae0a62ba39000acddc0755b78f4a535681db3b72abd57L75-R101) [[3]](diffhunk://#diff-3e35daebe129ff7baafae0a62ba39000acddc0755b78f4a535681db3b72abd57L64-R66); `convite_festa.py` [[4]](diffhunk://#diff-0dd7868358fc27528dd5d57f382b38c3467f29c2c52c2fd49fbef7b5a41beb09R17-R21) [[5]](diffhunk://#diff-0dd7868358fc27528dd5d57f382b38c3467f29c2c52c2fd49fbef7b5a41beb09L54-R103)
* Implemented logic so presencial sales are immediately marked as paid and present, bypassing Infinitepay and QR code flows. (`convite_festa.py` [[1]](diffhunk://#diff-0dd7868358fc27528dd5d57f382b38c3467f29c2c52c2fd49fbef7b5a41beb09R39-R42) [[2]](diffhunk://#diff-0dd7868358fc27528dd5d57f382b38c3467f29c2c52c2fd49fbef7b5a41beb09L41-R57)

**Manual entry and improved entry metrics:**

* Added `marcar_entrada_manual` endpoint to allow manual marking of entry for guests without QR codes, with auditing. (`gris/api/festas/portaria.py` [gris/api/festas/portaria.pyR170-R200](diffhunk://#diff-85c06ecaf8360f25941891603672f161bd88be28e9c52a27f153ca9b96800e1cR170-R200))
* Enhanced the `get_acompanhamento` metrics endpoint to distinguish between regular entries, entries from portaria sales, and provide breakdowns by origin and payment method. (`gris/api/festas/portaria.py` [[1]](diffhunk://#diff-85c06ecaf8360f25941891603672f161bd88be28e9c52a27f153ca9b96800e1cL346-R410) [[2]](diffhunk://#diff-85c06ecaf8360f25941891603672f161bd88be28e9c52a27f153ca9b96800e1cL402-R456)

**Data validation and guest handling:**

* Improved guest and payer validation to require only names for presencial sales and when the payer receives all QR codes, reducing unnecessary collection of personal data. (`convite_festa.py` [[1]](diffhunk://#diff-0dd7868358fc27528dd5d57f382b38c3467f29c2c52c2fd49fbef7b5a41beb09L131-R171) [[2]](diffhunk://#diff-0dd7868358fc27528dd5d57f382b38c3467f29c2c52c2fd49fbef7b5a41beb09R182-R192); `venda_convite.py` [[3]](diffhunk://#diff-019483ef7c3f547c2c9b1419b3699fac62e07df4c1a3d5d226cd2973cc2ae42fL179-R189) [[4]](diffhunk://#diff-019483ef7c3f547c2c9b1419b3699fac62e07df4c1a3d5d226cd2973cc2ae42fR200-R204)
* Updated field requirements in the data model so guest and payer email/phone are only mandatory for online sales. (`convite_festa.json` [[1]](diffhunk://#diff-3e35daebe129ff7baafae0a62ba39000acddc0755b78f4a535681db3b72abd57L64-R66) [[2]](diffhunk://#diff-3e35daebe129ff7baafae0a62ba39000acddc0755b78f4a535681db3b72abd57L75-R101); `convidado_convite_festa.json` [[3]](diffhunk://#diff-142c23afa2bf2056d560b43631764fbdf54f07c638412f277ea724fc4d969ebaL29-R29)

These changes improve support for real-world event operations, streamline the guest entry process, and ensure data is collected appropriately for each sales channel.