### PR TITLE
fix autofill

### DIFF
--- a/gris/www/festas/venda_convite.js
+++ b/gris/www/festas/venda_convite.js
@@ -334,6 +334,7 @@
 			atualizarBotaoContinuarPedido();
 		}).catch(function (err) {
 			tbody.innerHTML = '<tr><td colspan="3" class="text-sm text-destructive">' + escapeHtml(err.message || "Erro ao calcular pedido.") + "</td></tr>";
+			atualizarBotaoContinuarPedido();
 		});
 	}
 
@@ -381,13 +382,16 @@
 	}
 
 	function initPedidoControls() {
-		// Pagador — nome
+		// Pagador — nome. `change` cobre autofill do navegador (Safari/Chrome
+		// nem sempre disparam `input` em autofill ou restauração de sessão).
 		const nomeEl = document.getElementById("vc-pagador-nome");
 		if (nomeEl) {
-			nomeEl.addEventListener("input", function () {
+			const onNome = function () {
 				pagador.nome = nomeEl.value.trim();
 				atualizarBotaoContinuarPedido();
-			});
+			};
+			nomeEl.addEventListener("input", onNome);
+			nomeEl.addEventListener("change", onNome);
 		}
 
 		// Pagador — e-mail com validação
@@ -401,11 +405,13 @@
 			emailEl.setAttribute("aria-invalid", ok ? "false" : "true");
 		}
 		if (emailEl) {
-			emailEl.addEventListener("input", function () {
+			const onEmail = function () {
 				pagador.email = emailEl.value.trim();
 				if (emailErro && !emailErro.hidden) validarEmailUI();
 				atualizarBotaoContinuarPedido();
-			});
+			};
+			emailEl.addEventListener("input", onEmail);
+			emailEl.addEventListener("change", onEmail);
 			emailEl.addEventListener("blur", validarEmailUI);
 		}
 
@@ -840,7 +846,12 @@
 				if (btn.id === "btn-pedido-continuar" && !pagadorValido()) {
 					return;
 				}
-				if (target === "pedido") renderPedido();
+				if (target === "pedido") {
+					renderPedido();
+					// Re-valida imediatamente pra refletir o estado real do formulário
+					// sem esperar a API de resumo (que pode demorar ou falhar).
+					atualizarBotaoContinuarPedido();
+				}
 				if (target === "convidados") renderConvidados();
 				if (target === "revisao") renderRevisaoFinal();
 				activateTab(target);
@@ -896,5 +907,12 @@
 			}
 			carregarFesta(inicial);
 		}
+	});
+
+	// Restauração via bfcache (botão Voltar do navegador) não reexecuta
+	// DOMContentLoaded — força re-validação do botão pra refletir o que o
+	// navegador acabou de restaurar nos inputs.
+	window.addEventListener("pageshow", function (event) {
+		if (event.persisted) atualizarBotaoContinuarPedido();
 	});
 })();


### PR DESCRIPTION
This pull request improves the reliability and responsiveness of the form validation and UI updates in the `venda_convite.js` file, especially around handling browser autofill, session restoration, and navigation events. The changes ensure that the "Continuar Pedido" button and form validation state accurately reflect the current form data, even in edge cases like autofill or when returning to the page via the browser's back/forward cache.

**Form validation and UI updates:**

* Added `change` event listeners to the pagador name and email fields, in addition to `input`, to ensure updates are captured even when autofill or session restoration occurs (e.g., in Safari/Chrome) (`[[1]](diffhunk://#diff-8592488e8e72acc1dec95d4091ce2d1b54031facbb4e27e79ef4e8bc295026d7L384-R394)`, `[[2]](diffhunk://#diff-8592488e8e72acc1dec95d4091ce2d1b54031facbb4e27e79ef4e8bc295026d7L404-R414)`).
* After rendering the pedido tab, immediately re-validates the form and updates the "Continuar Pedido" button to reflect the real state of the form, without waiting for the API summary (which can be slow or fail) (`[gris/www/festas/venda_convite.jsL843-R854](diffhunk://#diff-8592488e8e72acc1dec95d4091ce2d1b54031facbb4e27e79ef4e8bc295026d7L843-R854)`).
* On errors during order calculation, ensures the "Continuar Pedido" button is updated to reflect the error state (`[gris/www/festas/venda_convite.jsR337](diffhunk://#diff-8592488e8e72acc1dec95d4091ce2d1b54031facbb4e27e79ef4e8bc295026d7R337)`).

**Browser navigation and session restoration:**

* Added a `pageshow` event handler to re-validate the "Continuar Pedido" button when the page is restored from the browser's back/forward cache (bfcache), ensuring the UI matches the restored form state (`[gris/www/festas/venda_convite.jsR911-R917](diffhunk://#diff-8592488e8e72acc1dec95d4091ce2d1b54031facbb4e27e79ef4e8bc295026d7R911-R917)`).