### PR TITLE
fix(festas): permitir excluir festa com portaria

### DIFF
--- a/gris/festas/doctype/area_da_festa/area_da_festa.py
+++ b/gris/festas/doctype/area_da_festa/area_da_festa.py
@@ -14,6 +14,8 @@ class AreadaFesta(Document):
 		self._validar_portaria()
 
 	def on_trash(self):
+		if self.flags.get("from_festa_delete"):
+			return
 		if self.nome_area == AREA_PORTARIA_NOME:
 			frappe.throw(
 				_("A área Portaria é obrigatória e não pode ser excluída.")

--- a/gris/festas/doctype/festa/festa.py
+++ b/gris/festas/doctype/festa/festa.py
@@ -35,6 +35,10 @@ class Festa(Document):
 		_garantir_area_portaria(self.name)
 		_enqueue_festa_drive_folder_creation(self.name)
 
+	def on_trash(self):
+		_excluir_dependencias_da_festa(self)
+		_desvincular_board_da_festa(self)
+
 	def on_update(self):
 		if getattr(self, "_cenario_antes", None) != (self.cenario_simulacao or "Intermediário"):
 			_enqueue_recalcular_compras(self.name)
@@ -497,6 +501,54 @@ def _ensure_festa_board(doc: Document) -> None:
 
 	frappe.db.set_value("Festa", doc.name, "board_tarefas", board.name, update_modified=False)
 	doc.board_tarefas = board.name
+
+
+def _excluir_dependencias_da_festa(doc: Document) -> None:
+	delete_plan = (
+		("Lista Entrada Festa", None),
+		("Convite Festa", None),
+		("Opcao Convite Festa", None),
+		("Compra Festa", None),
+		("Contratacao Festa", None),
+		("Produto de Venda Festa", None),
+		("Barraca da Festa", None),
+		("Avaliacao Festa", None),
+		("Area da Festa", {"from_festa_delete": True}),
+	)
+
+	for doctype, flags in delete_plan:
+		nomes = frappe.get_all(
+			doctype,
+			filters={"festa": doc.name},
+			pluck="name",
+			order_by="creation desc",
+		)
+		for nome in nomes:
+			frappe.delete_doc(doctype, nome, ignore_permissions=True, flags=flags)
+
+
+def _desvincular_board_da_festa(doc: Document) -> None:
+	board_names: list[str] = []
+	if doc.get("board_tarefas"):
+		board_names.append(doc.board_tarefas)
+
+	board_names.extend(
+		nome
+		for nome in frappe.get_all(
+			"Board",
+			filters={"referencia_doctype": "Festa", "referencia_nome": doc.name},
+			pluck="name",
+		)
+		if nome not in board_names
+	)
+
+	for board_name in board_names:
+		frappe.db.set_value(
+			"Board",
+			board_name,
+			{"referencia_doctype": "", "referencia_nome": ""},
+			update_modified=False,
+		)
 
 
 def _garantir_area_portaria(festa_name: str) -> None:

--- a/gris/festas/doctype/festa/test_festa_portaria.py
+++ b/gris/festas/doctype/festa/test_festa_portaria.py
@@ -50,6 +50,15 @@ class TestFestaPortaria(FrappeTestCase):
 			frappe.ValidationError, portaria.delete, ignore_permissions=True
 		)
 
+	def test_deletar_festa_remove_portaria_automaticamente(self):
+		festa = self._criar_festa()
+		self.assertTrue(frappe.db.exists("Area da Festa", f"{festa.name} - Portaria"))
+
+		frappe.delete_doc("Festa", festa.name, ignore_permissions=True)
+
+		self.assertFalse(frappe.db.exists("Festa", festa.name))
+		self.assertFalse(frappe.db.exists("Area da Festa", f"{festa.name} - Portaria"))
+
 	def test_portaria_sem_coordenador_falha_no_save_direto(self):
 		festa = self._criar_festa()
 		portaria = frappe.get_doc("Area da Festa", f"{festa.name} - Portaria")


### PR DESCRIPTION
This pull request introduces improvements to the deletion process for the `Festa` doctype, ensuring that all dependent records (including the mandatory "Portaria" area) are automatically and safely removed when a `Festa` is deleted. It also adds safeguards to prevent accidental deletion of the "Portaria" area outside the context of a `Festa` deletion, and includes a new test to verify this behavior.

**Enhancements to Festa deletion:**

* Implemented the `on_trash` method in `festa.py` to automatically remove all dependent records and unlink associated boards when a `Festa` is deleted.
* Added the `_excluir_dependencias_da_festa` function to delete related records, including "Area da Festa", using a special flag to bypass the protection for the "Portaria" area.
* Added the `_desvincular_board_da_festa` function to clear board references associated with the deleted `Festa`.

**Safeguards and validation:**

* Updated the `on_trash` method in `area_da_festa.py` to allow deletion of the "Portaria" area only if triggered by a `Festa` deletion, using the `from_festa_delete` flag.

**Testing:**

* Added a test (`test_deletar_festa_remove_portaria_automaticamente`) to ensure that deleting a `Festa` also deletes its "Portaria" area.