### PR TITLE
Melhoria no relatório de festas em PDF

### DIFF
--- a/gris/api/festas/relatorio.py
+++ b/gris/api/festas/relatorio.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import base64
 import io
+import math
 import os
 
 import frappe
@@ -221,6 +222,11 @@ def _montar_secao_convites(festa_name: str, convites_dashboard: dict) -> dict:
 	}
 
 
+def _distribuicao_0_10(notas: list[int]) -> list[int]:
+	"""Contagem de cada nota inteira de 0 a 10 (11 baldes), para os histogramas."""
+	return [sum(1 for n in notas if n == i) for i in range(11)]
+
+
 def _montar_avaliacoes(avaliacao: dict | None) -> dict | None:
 	"""Normaliza os dados de avaliação para o relatório, calculando o NPS dos
 	convidados e a distribuição das notas a partir das respostas."""
@@ -233,7 +239,22 @@ def _montar_avaliacoes(avaliacao: dict | None) -> dict | None:
 	promotores = sum(1 for n in notas if n >= 9)
 	detratores = sum(1 for n in notas if n <= 6)
 	nps_conv = (promotores - detratores) / total_conv if total_conv else 0.0
-	distribuicao = [sum(1 for n in notas if n == i) for i in range(11)]
+	distribuicao = _distribuicao_0_10(notas)
+
+	# Distribuição das notas da equipe (avaliações individuais concluídas): a
+	# satisfação em colaborar alimenta o NPS da equipe; o resultado da festa, a
+	# avaliação geral. Servem para os histogramas do relatório.
+	individuais = avaliacao.get("individuais") or []
+	notas_satisfacao = [
+		cint(i.get("satisfacao_colaboracao"))
+		for i in individuais
+		if i.get("satisfacao_colaboracao") not in (None, "")
+	]
+	notas_resultado = [
+		cint(i.get("resultado_festa"))
+		for i in individuais
+		if i.get("resultado_festa") not in (None, "")
+	]
 
 	return {
 		"geral": {
@@ -254,6 +275,8 @@ def _montar_avaliacoes(avaliacao: dict | None) -> dict | None:
 			"avaliacao_geral": flt(avaliacao.get("avaliacao_geral")),
 			"total": cint(avaliacao.get("total_individuais")),
 			"concluidas": cint(avaliacao.get("concluidas_individuais")),
+			"dist_nps": _distribuicao_0_10(notas_satisfacao),
+			"dist_geral": _distribuicao_0_10(notas_resultado),
 			"resumo_ia": avaliacao.get("resumo_avaliacoes_individuais", ""),
 		},
 	}
@@ -426,11 +449,60 @@ def build_relatorio_payload(festa_name: str) -> dict:
 	]
 	despesas_por_area.sort(key=lambda x: x["valor"], reverse=True)
 
+	# ── Arrecadação e resultado por área ────────────────────────────────────
+	# Receita realizada de cada barraca agrupada pela área a que pertence e o
+	# resultado por área (receita das barracas − despesas de compras/contratações).
+	# Áreas seguem a ordem de cadastro; barracas/despesas sem área vão ao final.
+	ordem_areas = [a.name for a in areas]
+
+	def _ordem_area(chave: str) -> tuple[int, str]:
+		return (ordem_areas.index(chave), "") if chave in ordem_areas else (len(ordem_areas), chave)
+
+	def _label_area(chave: str) -> str:
+		return area_nome.get(chave, "Sem área") if chave else "Sem área"
+
+	barracas_por_area: dict[str, list[dict]] = {}
+	receita_area: dict[str, float] = {}
+	for b in barracas:
+		chave = b.area or ""
+		valor = flt(b.valor_arrecadado_realizado_real)
+		barracas_por_area.setdefault(chave, []).append(
+			{"nome_barraca": b.nome_barraca or b.name, "valor": valor}
+		)
+		receita_area[chave] = receita_area.get(chave, 0.0) + valor
+
+	arrecadacao_por_area = [
+		{
+			"label": _label_area(chave),
+			"barracas": barracas_por_area[chave],
+			"subtotal": receita_area.get(chave, 0.0),
+		}
+		for chave in sorted(barracas_por_area, key=_ordem_area)
+	]
+	resultado_por_area = [
+		{
+			"label": _label_area(chave),
+			"receitas": receita_area.get(chave, 0.0),
+			"despesas": despesa_area.get(chave, 0.0),
+			"resultado": receita_area.get(chave, 0.0) - despesa_area.get(chave, 0.0),
+		}
+		for chave in sorted(set(receita_area) | set(despesa_area), key=_ordem_area)
+	]
+
 	# ── Totais do fechamento ────────────────────────────────────────────────
 	arrecadacao_barracas = sum(flt(b.valor_arrecadado_realizado_real) for b in barracas)
 	arrecadacao = receita_convites + receita_doacoes + arrecadacao_barracas
 	despesas = sum(x["valor"] for x in despesas_por_area)
 	resultado = arrecadacao - despesas
+
+	# Previsão do cenário escolhido (totais esperados gravados no doc Festa).
+	previsto_arrecadacao = flt(doc.get(f"receita_total_{sufixo}"))
+	previsto_despesas = flt(doc.get(f"despesa_total_{sufixo}"))
+	previsto = {
+		"arrecadacao": previsto_arrecadacao,
+		"despesas": previsto_despesas,
+		"resultado": previsto_arrecadacao - previsto_despesas,
+	}
 
 	# Passos do waterfall: entradas (+) e despesas por area (-); o JS acumula e
 	# fecha com a barra de Resultado.
@@ -462,10 +534,14 @@ def build_relatorio_payload(festa_name: str) -> dict:
 		"receita_convites": receita_convites,
 		"receita_doacoes": receita_doacoes,
 		"receitas_barracas": barracas_receita,
+		"arrecadacao_barracas": arrecadacao_barracas,
+		"arrecadacao_por_area": arrecadacao_por_area,
 		"despesas_por_area": despesas_por_area,
+		"resultado_por_area": resultado_por_area,
 		"arrecadacao": arrecadacao,
 		"despesas": despesas,
 		"resultado": resultado,
+		"previsto": previsto,
 		"compras": compras_payload,
 		"contratacoes": contratacoes_payload,
 		"avaliacoes": avaliacoes,
@@ -517,16 +593,142 @@ _CAPA_TEMPLATE = "templates/pages/relatorio_festa_pdf_capa.html"
 _CORPO_TEMPLATE = "templates/pages/relatorio_festa_pdf_corpo.html"
 
 
+# ── Paginação das tabelas "de lado" (compras/contratações) ─────────────────────
+# No corpo do PDF a seção de compras/contratações fica em folhas RETRATO com o
+# conteúdo rotacionado 90° (CSS `transform: rotate`), para a tabela larga caber. O
+# WeasyPrint aplica o transform DEPOIS do layout, então conteúdo transformado não
+# pagina sozinho — o que passa da folha é cortado. Por isso quebramos as linhas em
+# blocos aqui, estimando a altura de cada linha, de modo que cada bloco (uma
+# `.rot-canvas`) caiba em uma folha. Estimativas conservadoras (poucos caracteres
+# por linha → mais linhas previstas) preferem sobrar espaço a cortar conteúdo.
+_PAG_ALTURA_MM = 184.0      # espaço de empilhamento por folha (largura útil do retrato)
+_PAG_MARGEM_MM = 12.0       # folga de segurança
+_PAG_SEC_HEAD_MM = 22.0     # sec_head + h3 (só na 1ª folha das compras)
+_PAG_H3_MM = 8.0            # h3 "Contratações" / "(continuação)"
+_PAG_THEAD_MM = 16.0        # cabeçalho da tabela (repetido por folha; rótulos quebram em 2-3 linhas)
+_PAG_LINHA_MM = 4.4         # altura de uma linha de texto a 8pt
+_PAG_ROW_PAD_MM = 4.2       # padding vertical de uma <tr>
+
+
+def _altura_linha(celulas: list[tuple[str, int]]) -> float:
+    """Altura estimada (mm) de uma `<tr>`: a célula que mais quebra define a altura.
+
+    `celulas`: pares ``(texto, caracteres_por_linha_da_coluna)``.
+    """
+    linhas = 1
+    for texto, cpl in celulas:
+        if texto:
+            linhas = max(linhas, math.ceil(len(str(texto)) / cpl))
+    return linhas * _PAG_LINHA_MM + _PAG_ROW_PAD_MM
+
+
+def _paginar(linhas: list[dict], celulas_de, extra_primeira_mm: float) -> list[list[dict]]:
+    """Quebra `linhas` em blocos que cabem numa folha rotacionada.
+
+    `celulas_de(linha)` devolve os pares ``(texto, cpl)`` que estimam a altura da
+    linha. `extra_primeira_mm` é o cabeçalho extra que só aparece na 1ª folha.
+    Devolve sempre ao menos um bloco (vazio quando não há linhas) para o template
+    renderizar o estado "nenhum item cadastrado".
+    """
+    if not linhas:
+        return [[]]
+    cap_primeira = _PAG_ALTURA_MM - _PAG_MARGEM_MM - extra_primeira_mm - _PAG_THEAD_MM
+    cap_demais = _PAG_ALTURA_MM - _PAG_MARGEM_MM - _PAG_H3_MM - _PAG_THEAD_MM
+    paginas: list[list[dict]] = []
+    atual: list[dict] = []
+    restante = cap_primeira
+    for ln in linhas:
+        altura = _altura_linha(celulas_de(ln))
+        if atual and altura > restante:
+            paginas.append(atual)
+            atual = []
+            restante = cap_demais
+        atual.append(ln)
+        restante -= altura
+    paginas.append(atual)
+    return paginas
+
+
+# caracteres-por-linha de cada coluna que quebra (≈ largura útil / largura do
+# caractere a 8pt). Valores conservadores — derivados das larguras fixas do
+# `<colgroup>` no template — para superestimar a altura e nunca cortar linhas.
+def _paginar_compras(compras: list[dict]) -> list[list[dict]]:
+    def celulas(c: dict) -> list[tuple[str, int]]:
+        return [
+            (c.get("observacoes"), 38),       # obs: col. 68mm
+            (c.get("nome_item"), 14),         # item: col. 26mm
+            (c.get("fornecedor_orcado"), 15),  # fornecedor: col. 28mm
+            (c.get("fornecedor_realizado"), 15),
+        ]
+
+    return _paginar(compras, celulas, _PAG_SEC_HEAD_MM)
+
+
+def _paginar_contratacoes(contratacoes: list[dict]) -> list[list[dict]]:
+    def celulas(c: dict) -> list[tuple[str, int]]:
+        return [
+            (c.get("observacoes"), 38),       # obs: col. 68mm
+            (c.get("nome_item"), 20),         # nome: col. 42mm
+            (c.get("fornecedor_orcado"), 22),  # fornecedor: col. 46mm
+            (c.get("fornecedor_realizado"), 22),
+        ]
+
+    return _paginar(contratacoes, celulas, _PAG_H3_MM)
+
+
 def _logo_uel_data_uri() -> str:
-	"""Logo da UEL como data-URI PNG (mesmo carregamento do convite/QR)."""
+	"""Logo da UEL como data-URI PNG (mesmo carregamento do convite/QR), com
+	contorno branco para contraste sobre o gradiente escuro da capa."""
 	from gris.festas.utils.convite_qr import _carregar_logo
 
 	logo = _carregar_logo()
 	if logo is None:
 		return ""
+	logo = _com_contorno_branco(logo)
 	buf = io.BytesIO()
 	logo.save(buf, format="PNG")
 	return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
+
+
+def _com_contorno_branco(logo, proporcao: float = 0.06):
+	"""Recorta um contorno branco que segue a silhueta (alpha) do logo — efeito
+	"die-cut" de adesivo, para o logo ficar legível sobre o gradiente escuro da
+	capa. O WeasyPrint não gera esse contorno via CSS, então pré-processamos o PNG.
+
+	Dilata a máscara alpha carimbando-a num disco (contorno redondo e uniforme) e
+	usa a silhueta resultante para recortar uma camada branca, com o logo original
+	por cima. A espessura é `proporcao` da menor dimensão (independe da resolução).
+	"""
+	from PIL import Image, ImageChops
+
+	logo = logo.convert("RGBA")
+	bbox = logo.getbbox()
+	if bbox:
+		logo = logo.crop(bbox)
+	# O logo aparece pequeno na capa (~22mm) e o custo do contorno cresce com a
+	# espessura²; limitar a resolução de trabalho mantém o pré-processo barato.
+	limite = 480
+	if max(logo.size) > limite:
+		resample = getattr(Image, "Resampling", Image).LANCZOS
+		logo.thumbnail((limite, limite), resample)
+
+	espessura = max(4, round(min(logo.size) * proporcao))
+	alpha = logo.getchannel("A")
+	pad = espessura + 4
+	size = (logo.width + 2 * pad, logo.height + 2 * pad)
+
+	mascara = Image.new("L", size, 0)
+	for dy in range(-espessura, espessura + 1):
+		for dx in range(-espessura, espessura + 1):
+			if dx * dx + dy * dy <= espessura * espessura:
+				deslocado = Image.new("L", size, 0)
+				deslocado.paste(alpha, (pad + dx, pad + dy))
+				mascara = ImageChops.lighter(mascara, deslocado)
+
+	out = Image.new("RGBA", size, (255, 255, 255, 0))
+	out.paste(Image.new("RGBA", size, (255, 255, 255, 255)), (0, 0), mascara)
+	out.alpha_composite(logo, (pad, pad))
+	return out
 
 
 def _donut(pares: list[dict]) -> dict | None:
@@ -726,6 +928,9 @@ def _gerar_relatorio_pdf_bytes(festa_name: str) -> bytes:
 		"uel_nome": uel.get("nome_da_uel") or "",
 		"gerado_em": format_date(today(), "dd/MM/yyyy"),
 		"visuais": _build_pdf_visuais(payload),
+		# Compras/contratações já fatiadas em folhas (conteúdo rotacionado de lado).
+		"compras_paginas": _paginar_compras(payload["compras"]),
+		"contratacoes_paginas": _paginar_contratacoes(payload["contratacoes"]),
 	}
 
 	ctx["capa_html"] = _render_pdf_template(_CAPA_TEMPLATE, ctx)

--- a/gris/festas/doctype/avaliacao_festa/avaliacao_festa.py
+++ b/gris/festas/doctype/avaliacao_festa/avaliacao_festa.py
@@ -30,6 +30,12 @@ class AvaliacaoFesta(Document):
 		results: list[int] = []
 		satisfaction: list[int] = []
 		for ind in self.avaliacoes_individuais or []:
+			# Só linhas efetivamente respondidas entram nas métricas. As pendentes
+			# carregam o placeholder "0" do campo Select (resultado_festa/
+			# satisfacao_colaboracao) e distorceriam a média — espelha o tratamento
+			# de _serialize_avaliacao, que também só considera linhas concluídas.
+			if not cint(ind.avaliacao_concluida):
+				continue
 			if ind.resultado_festa is not None and str(ind.resultado_festa) != "":
 				results.append(cint(ind.resultado_festa))
 			if ind.satisfacao_colaboracao is not None and str(ind.satisfacao_colaboracao) != "":

--- a/gris/gestao_de_projetos/doctype/avaliacao_de_projeto/avaliacao_de_projeto.py
+++ b/gris/gestao_de_projetos/doctype/avaliacao_de_projeto/avaliacao_de_projeto.py
@@ -61,6 +61,10 @@ class AvaliacaodeProjeto(Document):
 		satisfaction: list[int] = []
 
 		for individual in self.avaliacoes_individuais or []:
+			# Só linhas efetivamente respondidas entram nas métricas: as pendentes
+			# carregam o placeholder "0" do campo Select e distorceriam a média.
+			if not cint(individual.avaliacao_concluida):
+				continue
 			if individual.resultado_projeto is not None and str(individual.resultado_projeto) != "":
 				results.append(cint(individual.resultado_projeto))
 			if individual.satisfacao_colaboracao is not None and str(individual.satisfacao_colaboracao) != "":

--- a/gris/templates/pages/relatorio_festa_pdf_capa.html
+++ b/gris/templates/pages/relatorio_festa_pdf_capa.html
@@ -6,24 +6,16 @@
 	<span class="cover__blob cover__blob--b"></span>
 
 	<header class="cover__top">
-		{% if uel_tipo or uel_nome %}
-		<div class="cover__kicker">{{ uel_tipo }} {{ uel_nome }}</div>
-		{% endif %}
+		{% if uel_logo %}<img class="cover__logo" src="{{ uel_logo }}" alt="Logo da UEL" />{% endif %}
 	</header>
 
 	<div class="cover__mid">
-		<h1 class="cover__title">{{ nome_festa }}</h1>
-		<span class="cover__rule"></span>
-		<p class="cover__subtitle">Relatório de execução</p>
+		<h1 class="cover__title">RELATÓRIO DE FESTA</h1>
+		<p class="cover__subtitle">{{ nome_festa }}</p>
+		{% if data_formatada %}<p class="cover__date">{{ data_formatada }}</p>{% endif %}
 	</div>
 
 	<footer class="cover__foot">
-		<div class="cover__card">
-			{% if uel_logo %}<img class="cover__logo" src="{{ uel_logo }}" alt="Logo da UEL" />{% endif %}
-			<div class="cover__org">
-				{% if uel_nome %}<div class="cover__uel">{{ uel_tipo }} {{ uel_nome }}</div>{% endif %}
-				<div class="cover__meta">Gerado em {{ gerado_em }}</div>
-			</div>
-		</div>
+		<div class="cover__meta">Gerado em {{ gerado_em }}</div>
 	</footer>
 </section>

--- a/gris/templates/pages/relatorio_festa_pdf_corpo.html
+++ b/gris/templates/pages/relatorio_festa_pdf_corpo.html
@@ -69,6 +69,82 @@
 	{% endfor %}
 </table>
 {% endmacro %}
+
+{% macro histograma(dist, cor="#1231E4") %}{# dist: 11 contagens (notas 0–10), barras verticais #}
+{% set dmax = (dist | max) or 1 %}
+<table class="vhisto">
+	<tr class="vhisto__plot">
+		{% for v in dist %}
+		<td><div class="vhisto__val">{{ v }}</div><div class="vhisto__bar" style="height:{{ (v/dmax*36)|round(1) }}mm;background:{{ cor }}{% if v %};min-height:0.8mm{% endif %}"></div></td>
+		{% endfor %}
+	</tr>
+	<tr class="vhisto__axis">
+		{% for v in dist %}<td>{{ loop.index0 }}</td>{% endfor %}
+	</tr>
+</table>
+{% endmacro %}
+
+{# Tabelas de compras/contratações (todas as colunas da página web, incluindo Obs.).
+   Recebem só as linhas de UMA folha — a paginação é feita no Python. #}
+{% macro tabela_compras(linhas) %}
+<table class="tbl tbl--wide">
+	<colgroup>
+		<col style="width:26mm"><col style="width:18mm"><col style="width:13mm"><col style="width:19mm">
+		<col style="width:28mm"><col style="width:18mm"><col style="width:13mm"><col style="width:19mm">
+		<col style="width:28mm"><col style="width:68mm">
+	</colgroup>
+	<thead><tr>
+		<th>Item</th>
+		<th class="num">Vlr unit. orç.</th>
+		<th class="num">Qtd orç.</th>
+		<th class="num">Total orç.</th>
+		<th>Fornecedor orç.</th>
+		<th class="num">Vlr unit. real.</th>
+		<th class="num">Qtd exec.</th>
+		<th class="num">Total exec.</th>
+		<th>Fornecedor real.</th>
+		<th class="obs">Obs.</th>
+	</tr></thead>
+	<tbody>
+		{% for c in linhas %}
+		<tr>
+			<td>{{ c.nome_item }}</td>
+			<td class="num">{{ brl(c.valor_individual_orcado) }}</td>
+			<td class="num">{{ qty(c.qtd_orcada) }}</td>
+			<td class="num">{{ brl(c.valor_total_orcado) }}</td>
+			<td>{{ c.fornecedor_orcado }}</td>
+			<td class="num">{{ brl(c.valor_individual_realizado) }}</td>
+			<td class="num">{{ qty(c.qtd_realizada) }}</td>
+			<td class="num">{{ brl(c.valor_total_realizado) }}</td>
+			<td>{{ c.fornecedor_realizado }}</td>
+			<td class="obs muted">{{ c.observacoes }}</td>
+		</tr>
+		{% endfor %}
+	</tbody>
+</table>
+{% endmacro %}
+
+{% macro tabela_contratacoes(linhas) %}
+<table class="tbl tbl--wide">
+	<colgroup>
+		<col style="width:42mm"><col style="width:24mm"><col style="width:46mm">
+		<col style="width:24mm"><col style="width:46mm"><col style="width:68mm">
+	</colgroup>
+	<thead><tr><th>Nome</th><th class="num">Valor orç.</th><th>Fornecedor orç.</th><th class="num">Valor real.</th><th>Fornecedor real.</th><th class="obs">Obs.</th></tr></thead>
+	<tbody>
+		{% for c in linhas %}
+		<tr>
+			<td>{{ c.nome_item }}</td>
+			<td class="num">{{ brl(c.valor_orcado) }}</td>
+			<td>{{ c.fornecedor_orcado }}</td>
+			<td class="num">{{ brl(c.valor_realizado) }}</td>
+			<td>{{ c.fornecedor_realizado }}</td>
+			<td class="obs muted">{{ c.observacoes }}</td>
+		</tr>
+		{% endfor %}
+	</tbody>
+</table>
+{% endmacro %}
 <!doctype html>
 <html lang="pt-BR">
 <head>
@@ -105,14 +181,31 @@
 		@page {
 			size: A4;
 			margin: 15mm 13mm 18mm 13mm;
-			/* Texto do rodapé em branco, alinhado ao fundo da margem para cair SOBRE a
-			   faixa de marca full-bleed (.footer-bar). Counter aqui é confiável. */
-			@bottom-left  { content: string(festatitle); font-family: "Figtree", sans-serif; font-size: 9.5pt;
+			/* Cabeçalho pequeno e centralizado (tipo + nome da UEL), dentro da margem
+			   superior (não empurra o conteúdo). Suprimido só na capa (@page cover). */
+			@top-center { content: string(uelinfo);
+				font-family: "Figtree", sans-serif; font-size: 8pt; font-weight: 500;
+				color: #8a90a2; vertical-align: middle; }
+			/* Rodapé em branco, alinhado ao fundo da margem para cair SOBRE a faixa de
+			   marca full-bleed (.footer-bar). "Relatório de Festa • festa • seção"
+			   (festaname/sectitle vêm de string-set); counter aqui é confiável.
+			   Esse texto é suprimido no índice (@page toc). */
+			@bottom-left  { content: "Relatório de Festa • " string(festaname) " • " string(sectitle);
+				font-family: "Figtree", sans-serif; font-size: 9.5pt;
 				color: #fff; vertical-align: bottom; padding: 0 0 4.6mm 7mm; }
 			@bottom-right { content: counter(page); font-family: "Figtree", sans-serif; font-size: 11pt;
 				font-weight: 800; color: #fff; vertical-align: bottom; padding: 0 7mm 4mm 0; }
 		}
-		@page cover { margin: 0; @bottom-left { content: none; } @bottom-right { content: none; } }
+		/* Mesmo gradiente no fundo da PÁGINA da capa: a .cover tem 296mm (297mm exato
+		   transborda p/ 2ª página no WeasyPrint 59), o que deixaria 1mm de página
+		   branca embaixo; o fundo do @page preenche essa faixa sem risco de overflow. */
+		@page cover { margin: 0;
+			background: linear-gradient(152deg, #5A45F8 0%, #2C3BEA 46%, #122C9E 84%, #0C1F6B 100%);
+			background-repeat: no-repeat;
+			@top-center { content: none; } @bottom-left { content: none; } @bottom-right { content: none; } }
+		/* Índice: mantém o cabeçalho (UEL) e o nº de página, mas sem o "Relatório de
+		   Festa • …" no rodapé esquerdo (a seção ainda não foi definida lá). */
+		@page toc { @bottom-left { content: none; } }
 
 		html, body { margin: 0; padding: 0; }
 		body { font-family: "Figtree", "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -123,8 +216,11 @@
 		   da página. O número/festa (margin boxes brancos) caem sobre ela. Coberta
 		   pela capa na 1ª página. Se mudar a margem do @page, ajuste estes offsets.
 		   NB: o WeasyPrint 59 não resolve var() dentro de linear-gradient() → hex. */
+		/* Degradê tonal só da primária do modo claro (#1231E4): primária exata nas
+		   pontas (texto branco legível) clareando levemente no centro. Hex literal
+		   porque o WeasyPrint 59 não resolve var()/oklch() dentro de linear-gradient(). */
 		.footer-bar { position: fixed; left: -13mm; right: -13mm; bottom: -18mm; height: 13mm; z-index: 1;
-			background: linear-gradient(90deg, #4F39F6 0%, #1231E4 55%, #00A516 100%); }
+			background: linear-gradient(90deg, #1231E4 0%, #3C54EE 50%, #1231E4 100%); }
 
 		.wrap { position: relative; z-index: 2; }
 		h3.sub { color: var(--ink); font-size: 11.5pt; margin: 7mm 0 2.5mm; font-weight: 700; letter-spacing: -.2px; }
@@ -136,7 +232,7 @@
 		   rodapé é absoluto com left/right fixando a largura (card nunca vaza); a
 		   altura 296mm + page-break-inside:avoid garantem a capa em 1 página. */
 		.cover { page: cover; position: relative; z-index: 10; overflow: hidden; page-break-inside: avoid;
-			width: 210mm; height: 296mm; box-sizing: border-box; padding: 24mm 20mm 0;
+			width: 210mm; height: 296mm; box-sizing: border-box; padding: 65mm 20mm 0;
 			color: #fff;
 			background: linear-gradient(152deg, #5A45F8 0%, #2C3BEA 46%, #122C9E 84%, #0C1F6B 100%); }
 		.cover__blob { position: absolute; border-radius: 50%; }
@@ -144,25 +240,19 @@
 			background: radial-gradient(circle at 50% 50%, rgba(255,255,255,0.14), rgba(255,255,255,0) 70%); }
 		.cover__blob--b { bottom: 30mm; left: -30mm; width: 120mm; height: 120mm;
 			background: radial-gradient(circle at 50% 50%, rgba(0,165,22,0.30), rgba(0,165,22,0) 70%); }
-		.cover__top { position: relative; z-index: 1; }
-		.cover__kicker { font-size: 10.5pt; font-weight: 700; letter-spacing: 3px; text-transform: uppercase; color: #6BF59A; }
+		.cover__top { position: relative; z-index: 1; text-align: center; }
 		.cover__mid { position: relative; z-index: 1; margin-top: 36mm; max-width: 168mm; }
-		.cover__title { font-size: 38pt; font-weight: 800; line-height: 1.04; letter-spacing: -1px; margin: 0;
+		.cover__title { font-size: 28pt; font-weight: 400; color: #DCE3FF; line-height: 1.06; letter-spacing: .5px; margin: 0;
 			max-width: 168mm; overflow-wrap: break-word; }
-		.cover__rule { display: block; width: 42mm; height: 5px; border-radius: 3px; margin: 9mm 0 6mm;
-			background: linear-gradient(90deg, #6BF59A, #00A516); }
-		.cover__subtitle { font-size: 15pt; font-weight: 500; color: #DCE3FF; margin: 0; letter-spacing: .2px; }
+		.cover__subtitle { font-size: 38pt; font-weight: 800; margin: 7mm 0 0; letter-spacing: .2px; }
+		.cover__date { font-size: 11pt; font-weight: 400; color: #B6C2EC; margin: 2.5mm 0 0; letter-spacing: .2px; }
+		.cover__logo { display: inline-block; height: 62mm; width: auto; max-width: 150mm; }
 		.cover__foot { position: absolute; left: 20mm; right: 20mm; bottom: 18mm; z-index: 1; }
-		.cover__card { display: flex; align-items: center; gap: 7mm;
-			background: rgba(255,255,255,0.96); border-radius: 14px; padding: 6mm 7mm; box-shadow: 0 6px 18px rgba(8,15,52,.28); }
-		.cover__logo { flex: none; height: 22mm; width: auto; max-width: 60mm; }
-		.cover__org { min-width: 0; border-left: 2px solid var(--border); padding-left: 6mm; }
-		.cover__uel { font-size: 13pt; font-weight: 800; color: var(--ink); }
-		.cover__meta { font-size: 9.5pt; color: var(--muted); margin-top: 1.5mm; }
+		.cover__meta { font-size: 9.5pt; color: #DCE3FF; }
 
 		/* ─────────── Seções (cada uma em nova página) ─────────── */
 		.sec { page-break-before: always; }
-		.sec--first { page-break-before: avoid; }
+		.sec--first { page-break-before: avoid; page: toc; }
 		/* inline-block (não flex): o flex do WeasyPrint 59 encolhe itens pequenos de
 		   tamanho fixo e colapsa o gap — o número viraria um disco minúsculo. */
 		.sec-head { margin: 0 0 6mm; padding-bottom: 4mm; border-bottom: 2px solid var(--border); }
@@ -170,7 +260,8 @@
 			font-size: 16pt; font-weight: 800; text-align: center; line-height: 15mm; vertical-align: middle;
 			margin-right: 5mm; background: linear-gradient(140deg, #4F39F6, #1231E4); }
 		.sec-head__txt { display: inline-block; vertical-align: middle; }
-		.sec-head__title { font-size: 16pt; font-weight: 800; color: var(--ink); letter-spacing: -.3px; }
+		.sec-head__title { font-size: 16pt; font-weight: 800; color: var(--ink); letter-spacing: -.3px;
+			string-set: sectitle content(); }
 		.sec-head__hint { font-size: 9pt; color: var(--muted); margin-top: 1mm; }
 
 		/* ─────────── Cards de destaque (flex) ─────────── */
@@ -201,6 +292,11 @@
 			border-radius: 999px; padding: 1mm 3mm; font-size: 8.5pt; font-weight: 600; margin: 0 1.5mm 1.5mm 0; }
 		.badge { display: inline-block; background: linear-gradient(140deg, #4F39F6, #1231E4);
 			color: #fff; border-radius: 6px; padding: 1mm 3mm; font-size: 9pt; font-weight: 700; }
+		/* Mini-cards empilhados: um abaixo do outro, largura total (sem dividir
+		   colunas). Bloco em vez de flex — o flex do WeasyPrint 59 é instável. */
+		.cards--stack { display: block; }
+		.cards--stack .mini { display: block; width: 100%; box-sizing: border-box; margin: 0 0 3mm; }
+		.cards--stack .mini:last-child { margin-bottom: 0; }
 
 		/* ─────────── Tabelas ─────────── */
 		table.tbl { width: 100%; border-collapse: collapse; margin: 2mm 0; font-size: 8.8pt; }
@@ -210,6 +306,34 @@
 		table.tbl tr:nth-child(even) td { background: var(--soft); }
 		table.tbl .num { text-align: right; white-space: nowrap; }
 		table.tbl tr.total td { font-weight: 800; color: var(--ink); border-top: 1.5px solid var(--brand-2); background: #fff; }
+		table.tbl tr.grouphead td { font-weight: 800; color: var(--ink); background: #fff; padding-top: 3.2mm; }
+		table.tbl tr.subtotal td { font-weight: 700; color: var(--ink); border-top: 1px solid var(--border); background: #fff; }
+		table.tbl td.indent { padding-left: 6mm; }
+		table.tbl td.pos { color: var(--accent); }
+		table.tbl td.neg { color: var(--danger); }
+		/* Tabelas largas (compras/contratações): fonte menor para caber todas as colunas.
+		   table-layout:fixed + colgroup travam a largura total em 100% da canvas — sem
+		   isso o conteúdo longo (fornecedores/obs) estica a tabela além da canvas e, como
+		   a largura da tabela vira a dimensão VERTICAL da página, ela invadia o rodapé.
+		   Todas as células quebram (overflow-wrap) e a Obs. tem coluna generosa; linhas com
+		   observação grande crescem (td já é vertical-align:top). */
+		table.tbl--wide { table-layout: fixed; width: 100%; font-size: 8pt; }
+		table.tbl--wide th, table.tbl--wide td { padding: 1.8mm 2mm; overflow-wrap: break-word; }
+		table.tbl--wide th.obs, table.tbl--wide td.obs { white-space: normal; word-break: break-word; }
+		/* O rótulo do cabeçalho numérico é mais longo que o valor; deixa quebrar para não
+		   estourar a coluna estreita e se sobrepor ao vizinho (o valor td.num segue nowrap). */
+		table.tbl--wide th.num { white-space: normal; }
+
+		/* Seção de compras/contratações: a FOLHA continua em retrato, mas o conteúdo é
+		   rotacionado 90° (de lado) para a tabela larga caber — gira-se a folha para ler.
+		   O WeasyPrint não pagina conteúdo transformado (o que passa da folha é cortado),
+		   então a paginação é feita no Python: cada .rot-canvas recebe só o bloco de linhas
+		   que cabe em uma folha (build_relatorio_payload → _paginar_compras/contratacoes).
+		   Geometria: a canvas é deitada (largura × altura = 250mm × 184mm). A largura (250mm)
+		   vira a dimensão vertical da página e fica < altura útil (264mm), deixando folga
+		   acima da faixa do rodapé; o translateX(184mm)+rotate(90°) encaixa na área útil. */
+		.rot-canvas { width: 250mm; height: 184mm; box-sizing: border-box;
+			transform-origin: top left; transform: translateX(184mm) rotate(90deg); }
 
 		/* ─────────── Barras horizontais ─────────── */
 		.bars { width: 100%; border-collapse: separate; border-spacing: 0 1.4mm; margin: 2mm 0; }
@@ -218,6 +342,18 @@
 		.bar__valcell { width: 30mm; text-align: right; font-size: 8.8pt; font-weight: 700; color: var(--ink); white-space: nowrap; padding-left: 3mm; }
 		.bar__track { height: 5mm; background: #EEF0F4; border-radius: 5px; overflow: hidden; }
 		.bar__fill { height: 5mm; border-radius: 5px; }
+
+		/* ─────────── Histograma vertical (distribuição de notas 0–10) ───────────
+		   Barras crescem do eixo: células com vertical-align:bottom (estável no
+		   WeasyPrint 59, ao contrário do flex). A altura da barra vem do Python via
+		   estilo inline (mm). table-layout:fixed mantém as 11 colunas iguais. */
+		.vhisto { width: 100%; border-collapse: collapse; table-layout: fixed; margin: 2mm 0; page-break-inside: avoid; }
+		.vhisto td { text-align: center; }
+		.vhisto__plot td { height: 38mm; vertical-align: bottom; padding: 0 1mm; }
+		.vhisto__bar { width: 6mm; margin: 0 auto; border-radius: 2px 2px 0 0; }
+		.vhisto__val { font-size: 7.5pt; font-weight: 700; color: var(--ink); margin-bottom: 0.6mm; }
+		.vhisto__axis td { font-size: 8.5pt; font-weight: 700; color: var(--muted);
+			padding-top: 1mm; border-top: 1px solid var(--border); }
 
 		/* ─────────── Donut + SVG ─────────── */
 		.donut { display: flex; align-items: center; gap: 4mm; border: 1px solid var(--border);
@@ -257,12 +393,19 @@
 		.part-block__coord { font-size: 8.5pt; color: var(--muted); white-space: nowrap; }
 		.part-team { margin: 0; padding-left: 4mm; font-size: 9pt; }
 		.part-team li { margin-bottom: .5mm; }
+		.part-team li.is-coord { list-style: none; margin-left: -4mm; }
+		.part-badge { display: inline-block; background: linear-gradient(140deg, #4F39F6, #1231E4); color: #fff;
+			border-radius: 999px; padding: .2mm 2.4mm; font-size: 7pt; font-weight: 700; text-transform: uppercase;
+			letter-spacing: .4px; vertical-align: middle; margin-left: 2mm; }
 
 		/* ─────────── Índice ─────────── */
 		.toc-head { margin: 2mm 0 7mm; }
 		.toc-eyebrow { font-size: 9.5pt; font-weight: 700; letter-spacing: 2.5px; text-transform: uppercase; color: var(--brand-2); }
 		.toc-title { color: var(--ink); font-size: 26pt; font-weight: 800; margin: 1.5mm 0 1mm; letter-spacing: -.6px;
-			string-set: festatitle content(); }
+			string-set: festaname content(); }
+		/* Fonte da string do rodapé esquerdo (tipo + nome da UEL): elemento sem altura
+		   cujo texto alimenta string(uelinfo) nas margin boxes do @page. */
+		.uel-footer-str { display: block; height: 0; overflow: hidden; font-size: 0; string-set: uelinfo content(); }
 		.toc-sub { color: var(--muted); margin: 0; font-size: 10pt; }
 		.toc-item { display: block; border-bottom: 1px solid #EDEFF4; padding: 3.4mm 0; text-decoration: none; color: inherit; }
 		.toc-num { display: inline-block; width: 9mm; height: 9mm; line-height: 9mm; text-align: center; border-radius: 50%;
@@ -279,11 +422,12 @@
 	{{ capa_html | safe }}
 	<div class="footer-bar"></div>
 	<div class="wrap">
+	<span class="uel-footer-str">{{ (uel_tipo ~ " " ~ uel_nome) | trim }}</span>
 
 	{# ───────── Índice ───────── #}
 	<section class="sec sec--first">
 		<div class="toc-head">
-			<div class="toc-eyebrow">Relatório de execução</div>
+			<div class="toc-eyebrow">Relatório de Festa</div>
 			<div class="toc-title">{{ nome_festa }}</div>
 			<p class="toc-sub">Gerado em {{ gerado_em }}</p>
 		</div>
@@ -305,7 +449,7 @@
 			<div class="field" style="flex:1"><dt>Horário</dt><dd>{{ horario_inicio or "—" }}{% if horario_termino %} – {{ horario_termino }}{% endif %}</dd></div>
 		</div>
 		<div class="fieldgrid">
-			<div class="field" style="flex:1 1 100%"><dt>Coordenador geral</dt><dd>{{ nome_coord_geral or "—" }}</dd></div>
+			<div class="field" style="flex:1 1 100%"><dt>coordenador(a) geral</dt><dd>{{ nome_coord_geral or "—" }}</dd></div>
 		</div>
 
 		<h3 class="sub">Estimativa de participantes</h3>
@@ -397,6 +541,19 @@
 			{{ stat("Resultado", brl(resultado), "pos" if resultado >= 0 else "neg") }}
 		</div>
 
+		<h3 class="sub">Previsto x realizado</h3>
+		<p class="muted" style="margin:0 0 1mm;font-size:8.5pt;">Previsão com base no cenário <strong>{{ cenario_simulacao }}</strong>.</p>
+		<table class="tbl">
+			<thead><tr><th>Indicador</th><th class="num">Previsto</th><th class="num">Realizado</th></tr></thead>
+			<tbody>
+				<tr><td>Arrecadação</td><td class="num">{{ brl(previsto.arrecadacao) }}</td><td class="num">{{ brl(arrecadacao) }}</td></tr>
+				<tr><td>Despesas</td><td class="num">{{ brl(previsto.despesas) }}</td><td class="num">{{ brl(despesas) }}</td></tr>
+				<tr class="total"><td>Resultado</td>
+					<td class="num {{ 'pos' if previsto.resultado >= 0 else 'neg' }}">{{ brl(previsto.resultado) }}</td>
+					<td class="num {{ 'pos' if resultado >= 0 else 'neg' }}">{{ brl(resultado) }}</td></tr>
+			</tbody>
+		</table>
+
 		<h3 class="sub">Receitas</h3>
 		<table class="tbl">
 			<thead><tr><th>Origem</th><th class="num">Valor</th></tr></thead>
@@ -413,6 +570,22 @@
 		{{ barras(receitas_barracas, "#1231E4") }}
 		{% endif %}
 
+		{% if arrecadacao_por_area %}
+		<h3 class="sub">Arrecadação por área</h3>
+		<p class="muted" style="margin:0 0 1mm;font-size:8.5pt;">Arrecadação das barracas agrupada por área. Convites e doações não entram por não pertencerem a uma área.</p>
+		<table class="tbl">
+			<thead><tr><th>Área / barraca</th><th class="num">Arrecadado</th></tr></thead>
+			<tbody>
+				{% for a in arrecadacao_por_area %}
+				<tr class="grouphead"><td>{{ a.label }}</td><td></td></tr>
+				{% for b in a.barracas %}<tr><td class="indent">{{ b.nome_barraca }}</td><td class="num">{{ brl(b.valor) }}</td></tr>{% endfor %}
+				<tr class="subtotal"><td class="indent">Subtotal {{ a.label }}</td><td class="num">{{ brl(a.subtotal) }}</td></tr>
+				{% endfor %}
+				<tr class="total"><td>Total de receitas</td><td class="num">{{ brl(arrecadacao_barracas) }}</td></tr>
+			</tbody>
+		</table>
+		{% endif %}
+
 		<h3 class="sub">Despesas por área</h3>
 		<table class="tbl">
 			<thead><tr><th>Área</th><th class="num">Valor</th></tr></thead>
@@ -420,6 +593,23 @@
 				{% for d in despesas_por_area %}<tr><td>{{ d.label }}</td><td class="num">{{ brl(d.valor) }}</td></tr>
 				{% else %}<tr><td colspan="2" class="muted">Sem despesas realizadas.</td></tr>{% endfor %}
 				<tr class="total"><td>Total de despesas</td><td class="num">{{ brl(despesas) }}</td></tr>
+			</tbody>
+		</table>
+
+		<h3 class="sub">Resultado por área</h3>
+		<p class="muted" style="margin:0 0 1mm;font-size:8.5pt;">Receitas das barracas menos despesas de cada área. Convites e doações não entram por não pertencerem a uma área.</p>
+		<table class="tbl">
+			<thead><tr><th>Área</th><th class="num">Receitas</th><th class="num">Despesas</th><th class="num">Resultado</th></tr></thead>
+			<tbody>
+				{% for r in resultado_por_area %}
+				<tr>
+					<td>{{ r.label }}</td>
+					<td class="num">{{ brl(r.receitas) }}</td>
+					<td class="num">{{ brl(r.despesas) }}</td>
+					<td class="num {{ 'pos' if r.resultado >= 0 else 'neg' }}">{{ brl(r.resultado) }}</td>
+				</tr>
+				{% else %}<tr><td colspan="4" class="muted">Sem dados por área.</td></tr>{% endfor %}
+				<tr class="total"><td>Total</td><td class="num">{{ brl(arrecadacao_barracas) }}</td><td class="num">{{ brl(despesas) }}</td><td class="num {{ 'pos' if (arrecadacao_barracas - despesas) >= 0 else 'neg' }}">{{ brl(arrecadacao_barracas - despesas) }}</td></tr>
 			</tbody>
 		</table>
 
@@ -467,55 +657,36 @@
 		{% else %}<p class="empty">Nenhuma barraca cadastrada.</p>{% endif %}
 	</section>
 
-	{# ───────── 5. Compras e contratações ───────── #}
-	<section class="sec" id="sec-5">
-		{{ sec_head(5, "Lista de compras e contratações", "Orçado x realizado de cada item.") }}
-		<h3 class="sub">Compras</h3>
-		{% if compras %}
-		<table class="tbl">
-			<thead><tr><th>Item</th><th class="num">Qtd orç.</th><th class="num">Total orç.</th><th class="num">Qtd real.</th><th class="num">Total real.</th><th>Fornecedor real.</th><th>Obs.</th></tr></thead>
-			<tbody>
-				{% for c in compras %}
-				<tr>
-					<td>{{ c.nome_item }}</td>
-					<td class="num">{{ qty(c.qtd_orcada) }}</td>
-					<td class="num">{{ brl(c.valor_total_orcado) }}</td>
-					<td class="num">{{ qty(c.qtd_realizada) }}</td>
-					<td class="num">{{ brl(c.valor_total_realizado) }}</td>
-					<td>{{ c.fornecedor_realizado }}</td>
-					<td class="muted">{{ c.observacoes }}</td>
-				</tr>
-				{% endfor %}
-			</tbody>
-		</table>
-		{% else %}<p class="empty">Nenhuma compra cadastrada.</p>{% endif %}
-
-		<h3 class="sub">Contratações</h3>
-		{% if contratacoes %}
-		<table class="tbl">
-			<thead><tr><th>Nome</th><th class="num">Valor orç.</th><th>Fornecedor orç.</th><th class="num">Valor real.</th><th>Fornecedor real.</th><th>Obs.</th></tr></thead>
-			<tbody>
-				{% for c in contratacoes %}
-				<tr>
-					<td>{{ c.nome_item }}</td>
-					<td class="num">{{ brl(c.valor_orcado) }}</td>
-					<td>{{ c.fornecedor_orcado }}</td>
-					<td class="num">{{ brl(c.valor_realizado) }}</td>
-					<td>{{ c.fornecedor_realizado }}</td>
-					<td class="muted">{{ c.observacoes }}</td>
-				</tr>
-				{% endfor %}
-			</tbody>
-		</table>
-		{% else %}<p class="empty">Nenhuma contratação cadastrada.</p>{% endif %}
+	{# ───────── 5. Compras e contratações — folhas em retrato com o conteúdo de lado ─────────
+	   Cada bloco (página) já vem dimensionado do Python (compras_paginas /
+	   contratacoes_paginas) para caber em uma folha rotacionada. A âncora #sec-5 do
+	   índice fica na 1ª folha de compras. #}
+	{% for pagina in compras_paginas %}
+	<section class="sec sec--rot"{% if loop.first %} id="sec-5"{% endif %}>
+		<div class="rot-canvas">
+			{% if loop.first %}{{ sec_head(5, "Lista de compras e contratações", "Orçado x realizado de cada item.") }}{% endif %}
+			<h3 class="sub">Compras{% if not loop.first %} (continuação){% endif %}</h3>
+			{% if pagina %}{{ tabela_compras(pagina) }}
+			{% else %}<p class="empty">Nenhuma compra cadastrada.</p>{% endif %}
+		</div>
 	</section>
+	{% endfor %}
+	{% for pagina in contratacoes_paginas %}
+	<section class="sec sec--rot">
+		<div class="rot-canvas">
+			<h3 class="sub">Contratações{% if not loop.first %} (continuação){% endif %}</h3>
+			{% if pagina %}{{ tabela_contratacoes(pagina) }}
+			{% else %}<p class="empty">Nenhuma contratação cadastrada.</p>{% endif %}
+		</div>
+	</section>
+	{% endfor %}
 
 	{# ───────── 6. Avaliações ───────── #}
 	<section class="sec" id="sec-6">
 		{{ sec_head(6, "Avaliações", "Avaliação geral, dos convidados e da equipe.") }}
 		{% if avaliacoes %}
 		<h3 class="sub">Avaliação geral da festa</h3>
-		<div class="cards">
+		<div class="cards cards--stack">
 			<div class="mini"><div class="mini__title">O que funcionou bem na dinâmica da equipe</div><p class="text">{{ avaliacoes.geral.funcionou_bem or "—" }}</p></div>
 			<div class="mini"><div class="mini__title">O que não funcionou na dinâmica da equipe</div><p class="text">{{ avaliacoes.geral.nao_funcionou or "—" }}</p></div>
 			<div class="mini"><div class="mini__title">Pontos positivos adicionais</div><p class="text">{{ avaliacoes.geral.pontos_positivos or "—" }}</p></div>
@@ -532,16 +703,8 @@
 		</div>
 		{% set dist = avaliacoes.convidados.distribuicao %}
 		{% if dist and (dist | sum) > 0 %}
-		{% set dmax = (dist | max) or 1 %}
-		<table class="bars">
-			{% for v in dist %}
-			<tr>
-				<td class="bar__label" style="width:16mm;">Nota {{ loop.index0 }}</td>
-				<td><div class="bar__track"><div class="bar__fill" style="width:{{ (v/dmax*100)|round(1) }}%;background:#1231E4"></div></div></td>
-				<td class="bar__valcell" style="width:18mm;">{{ v }}</td>
-			</tr>
-			{% endfor %}
-		</table>
+		<p class="muted" style="margin:0 0 1mm;font-size:8.5pt;">Distribuição das notas de recomendação (0–10).</p>
+		{{ histograma(dist) }}
 		{% else %}<p class="empty">Sem respostas numéricas dos convidados.</p>{% endif %}
 		{% if avaliacoes.convidados.resumo_ia %}
 		<div class="ia"><div class="ia__label">✦ Resumo por IA</div><div class="ia__md">{{ frappe.utils.markdown(avaliacoes.convidados.resumo_ia) | safe }}</div></div>
@@ -555,6 +718,14 @@
 			{{ stat("Avaliação geral", ("%.1f"|format(eq.avaliacao_geral)) ~ " /10") }}
 			{{ stat("Respostas", (eq.concluidas ~ " de " ~ eq.total ~ " (" ~ ("%.0f"|format(taxa)) ~ "%)")) }}
 		</div>
+		{% if eq.dist_nps and (eq.dist_nps | sum) > 0 %}
+		<p class="muted" style="margin:2mm 0 1mm;font-size:8.5pt;">Distribuição da satisfação em colaborar com a festa (0–10).</p>
+		{{ histograma(eq.dist_nps) }}
+		{% endif %}
+		{% if eq.dist_geral and (eq.dist_geral | sum) > 0 %}
+		<p class="muted" style="margin:2mm 0 1mm;font-size:8.5pt;">Distribuição da avaliação do resultado da festa (0–10).</p>
+		{{ histograma(eq.dist_geral) }}
+		{% endif %}
 		{% if eq.resumo_ia %}
 		<div class="ia"><div class="ia__label">✦ Resumo por IA</div><div class="ia__md">{{ frappe.utils.markdown(eq.resumo_ia) | safe }}</div></div>
 		{% endif %}
@@ -565,7 +736,7 @@
 	<section class="sec" id="sec-7">
 		{{ sec_head(7, "Participantes por área e barraca", "Coordenação geral, áreas e barracas com suas equipes.") }}
 		<div class="part-coord">
-			<div class="lbl">Coordenador geral</div>
+			<div class="lbl">coordenador(a) geral</div>
 			<div class="nome">{{ nome_coord_geral or "—" }}</div>
 		</div>
 
@@ -575,10 +746,12 @@
 		<div class="part-block">
 			<div class="part-block__head">
 				<span class="part-block__name">{{ area.nome_area }}</span>
-				<span class="part-block__coord">Coord.: {{ area.nome_coord or "—" }}</span>
 			</div>
-			{% if area.equipe %}
-			<ul class="part-team">{% for m in area.equipe %}<li>{{ m.nome }}{% if m.funcao %} <span class="muted">— {{ m.funcao }}</span>{% endif %}</li>{% endfor %}</ul>
+			{% if area.nome_coord or area.equipe %}
+			<ul class="part-team">
+				{% if area.nome_coord %}<li class="is-coord">{{ area.nome_coord }}<span class="part-badge">coordenador(a)</span></li>{% endif %}
+				{% for m in area.equipe %}{% if not (area.nome_coord and m.nome == area.nome_coord) %}<li>{{ m.nome }}{% if m.funcao %} <span class="muted">— {{ m.funcao }}</span>{% endif %}</li>{% endif %}{% endfor %}
+			</ul>
 			{% else %}<p class="empty" style="margin:0;">Sem equipe cadastrada.</p>{% endif %}
 		</div>
 		{% endfor %}
@@ -590,10 +763,12 @@
 		<div class="part-block">
 			<div class="part-block__head">
 				<span class="part-block__name">{{ b.nome_barraca }}</span>
-				<span class="part-block__coord">Coord.: {{ b.nome_coord or "—" }}</span>
 			</div>
-			{% if b.equipe %}
-			<ul class="part-team">{% for m in b.equipe %}<li>{{ m.nome }}{% if m.funcao %} <span class="muted">— {{ m.funcao }}</span>{% endif %}</li>{% endfor %}</ul>
+			{% if b.nome_coord or b.equipe %}
+			<ul class="part-team">
+				{% if b.nome_coord %}<li class="is-coord">{{ b.nome_coord }}<span class="part-badge">coordenador(a)</span></li>{% endif %}
+				{% for m in b.equipe %}{% if not (b.nome_coord and m.nome == b.nome_coord) %}<li>{{ m.nome }}{% if m.funcao %} <span class="muted">— {{ m.funcao }}</span>{% endif %}</li>{% endif %}{% endfor %}
+			</ul>
 			{% else %}<p class="empty" style="margin:0;">Sem equipe cadastrada.</p>{% endif %}
 		</div>
 		{% endfor %}


### PR DESCRIPTION
This pull request introduces significant improvements to the Festa report generation, focusing on more accurate metrics, enhanced financial breakdowns, improved PDF rendering (especially for wide tables), and a modernized, clearer report cover. The changes affect both backend logic and frontend templates, ensuring data accuracy and better visual presentation.

**Data accuracy and metrics:**

* Individual evaluations now only count completed responses, preventing placeholder values from skewing averages and distributions (`gris/festas/doctype/avaliacao_festa/avaliacao_festa.py`, `gris/gestao_de_projetos/doctype/avaliacao_de_projeto/avaliacao_de_projeto.py`). [[1]](diffhunk://#diff-4cb48a40bb2434335a53b2f3b61ebf96161ce1755fe210825a98a515920f719eR33-R38) [[2]](diffhunk://#diff-983934364e14e25dd02041ab6c5e61bad1c9ee864353d3c868fb8843f83d7432R64-R67)
* Added distribution histograms for evaluation scores (0–10) for both general and team NPS metrics, with a helper function for consistent bucketing (`gris/api/festas/relatorio.py`). [[1]](diffhunk://#diff-be3ab0519723f01d6af9fafa641769dcde57271ff700b9d2a9b68c9bc57c7b83R225-R229) [[2]](diffhunk://#diff-be3ab0519723f01d6af9fafa641769dcde57271ff700b9d2a9b68c9bc57c7b83L236-R257) [[3]](diffhunk://#diff-be3ab0519723f01d6af9fafa641769dcde57271ff700b9d2a9b68c9bc57c7b83R278-R279)

**Financial breakdown enhancements:**

* The report now includes detailed revenue and result breakdowns by area, grouping stalls and expenses, and presenting subtotals and results per area (`gris/api/festas/relatorio.py`). [[1]](diffhunk://#diff-be3ab0519723f01d6af9fafa641769dcde57271ff700b9d2a9b68c9bc57c7b83R452-R506) [[2]](diffhunk://#diff-be3ab0519723f01d6af9fafa641769dcde57271ff700b9d2a9b68c9bc57c7b83R537-R544)
* Added expected (planned) totals to the report for revenue, expenses, and results, improving comparison with actuals (`gris/api/festas/relatorio.py`). [[1]](diffhunk://#diff-be3ab0519723f01d6af9fafa641769dcde57271ff700b9d2a9b68c9bc57c7b83R452-R506) [[2]](diffhunk://#diff-be3ab0519723f01d6af9fafa641769dcde57271ff700b9d2a9b68c9bc57c7b83R537-R544)

**PDF rendering and visual improvements:**

* Implemented pagination logic for wide tables (purchases and contracts) in the PDF, ensuring content is not cut off when rotated and rendered (`gris/api/festas/relatorio.py`). [[1]](diffhunk://#diff-be3ab0519723f01d6af9fafa641769dcde57271ff700b9d2a9b68c9bc57c7b83R596-R733) [[2]](diffhunk://#diff-be3ab0519723f01d6af9fafa641769dcde57271ff700b9d2a9b68c9bc57c7b83R931-R933)
* Added histogram and paginated table macros to the PDF template, improving data visualization and layout (`gris/templates/pages/relatorio_festa_pdf_corpo.html`).
* Redesigned the report cover for clarity and branding: the logo is now prominent, the title is standardized, and the date is highlighted (`gris/templates/pages/relatorio_festa_pdf_capa.html`).
* The UEL logo now receives a white outline for better contrast on dark backgrounds, processed at PDF generation (`gris/api/festas/relatorio.py`).

**Styling and layout:**

* Updated PDF page styles for a more modern look: improved gradients, header/footer content, and clearer sectioning (`gris/templates/pages/relatorio_festa_pdf_corpo.html`). [[1]](diffhunk://#diff-e2a1513f5e1c1163508e95df2bd5c898cfd0659f0d290452d3f9f51fad62aa87L108-R208) [[2]](diffhunk://#diff-e2a1513f5e1c1163508e95df2bd5c898cfd0659f0d290452d3f9f51fad62aa87R219-R223)

These changes collectively enhance the accuracy, clarity, and professionalism of the Festa report, both in data and presentation.