### PR TITLE
Corrige comportamento de popover aninhado

### DIFF
--- a/gris/public/design_system/js/components/popover.js
+++ b/gris/public/design_system/js/components/popover.js
@@ -162,7 +162,11 @@
     });
 
     document.addEventListener('basecoat:popover', (event) => {
-      if (event.detail.source !== popoverComponent) {
+      // Não fecha quando o popover/select que está abrindo é um descendente
+      // deste (ex.: um select dentro do conteúdo do popover). Sem essa guarda,
+      // abrir um select aninhado dispararia o fechamento do popover pai.
+      const source = event.detail.source;
+      if (source !== popoverComponent && !popoverComponent.contains(source)) {
         closePopover(false);
       }
     });

--- a/gris/public/design_system/js/components/select.js
+++ b/gris/public/design_system/js/components/select.js
@@ -497,7 +497,11 @@
     });
 
     addListener(document, 'basecoat:popover', (event) => {
-      if (event.detail.source !== selectComponent) {
+      // Não fecha quando o popover/select que está abrindo é um descendente
+      // deste select (cenário aninhado). Mantém o comportamento de fechar
+      // selects/popovers irmãos ou não relacionados.
+      const source = event.detail.source;
+      if (source !== selectComponent && !selectComponent.contains(source)) {
         closePopover(false);
       }
     });

--- a/gris/templates/base.html
+++ b/gris/templates/base.html
@@ -1,6 +1,6 @@
 {% extends "frappe/templates/base.html" %}
 
-{% set design_system_asset_version = "20260511-smart-popover" %}
+{% set design_system_asset_version = "20260609-nested-popover" %}
 {% set current_page_path = pathname if pathname is defined and pathname else (path if path is defined else "") %}
 {# Frappe entrega `pathname` sem a barra inicial (ex.: "inicio", "projetos/abc"). Normalizamos para comparar com segurança independentemente do contexto. #}
 {% set normalized_page_path = current_page_path.lstrip("/") %}


### PR DESCRIPTION
This pull request updates the popover and select components to better handle nested popover scenarios, preventing parent popovers from closing when a child popover or select is opened. It also updates the asset version to reflect these changes.

**Popover and Select Behavior Improvements:**

* Updated `popover.js` to prevent the parent popover from closing when a nested popover or select within its content is opened, by checking if the event source is a descendant of the current popover.
* Updated `select.js` with similar logic to avoid closing the parent select when a nested select or popover is opened inside it, ensuring only sibling or unrelated popovers/selects trigger closure.

**Asset Version Update:**

* Changed the `design_system_asset_version` in `base.html` to `"20260609-nested-popover"` to signal the new nested popover handling.