### PR TITLE
Corrige e-mail para id@escoteiros nos membros de barracas e áreas de …

### DIFF
--- a/gris/api/festas/__init__.py
+++ b/gris/api/festas/__init__.py
@@ -27,6 +27,13 @@ def _validate_tipo_coord(tipo: str) -> None:
 		frappe.throw("Tipo de coordenador inválido.")
 
 
+def _associado_email(name: str) -> str:
+	"""E-mail preferencial do associado: usa o id@escoteiros quando preenchido,
+	senão cai para o e-mail comum."""
+	dados = frappe.db.get_value("Associado", name, ["id_escoteiros", "email"], as_dict=True) or {}
+	return (dados.get("id_escoteiros") or dados.get("email") or "").strip()
+
+
 # ---------------------------------------------------------------------------
 # Coordenador da festa
 # ---------------------------------------------------------------------------
@@ -259,7 +266,7 @@ def salvar_area(area_name: str, dados_json: str) -> dict:
 		doc.responsavel_coord = None
 		nome_coord = frappe.db.get_value("Associado", coord, "nome_completo") or coord
 		doc.nome_coord = nome_coord
-		doc.email_coord = frappe.db.get_value("Associado", coord, "email") or ""
+		doc.email_coord = _associado_email(coord)
 		doc.telefone_coord = frappe.db.get_value("Associado", coord, "telefone") or ""
 	else:
 		doc.responsavel_coord = None
@@ -284,6 +291,10 @@ def salvar_area(area_name: str, dados_json: str) -> dict:
 		if tipo_pessoa == "Associado":
 			entry["associado"] = (row.get("associado") or "").strip() or None
 			entry["responsavel"] = None
+			if entry["associado"]:
+				# Resolve no servidor para garantir o id@escoteiros quando houver,
+				# em vez de confiar no e-mail enviado pelo client.
+				entry["email"] = _associado_email(entry["associado"]) or entry["email"]
 		elif tipo_pessoa == "Responsavel":
 			entry["responsavel"] = (row.get("responsavel") or "").strip() or None
 			entry["associado"] = None
@@ -400,7 +411,7 @@ def salvar_barraca(barraca_name: str, dados_json: str) -> dict:
 		doc.responsavel_coord = None
 		nome_coord = frappe.db.get_value("Associado", coord, "nome_completo") or coord
 		doc.nome_coord = nome_coord
-		doc.email_coord = frappe.db.get_value("Associado", coord, "email") or ""
+		doc.email_coord = _associado_email(coord)
 		doc.telefone_coord = frappe.db.get_value("Associado", coord, "telefone") or ""
 	else:
 		doc.responsavel_coord = None
@@ -425,6 +436,10 @@ def salvar_barraca(barraca_name: str, dados_json: str) -> dict:
 		if tipo_pessoa == "Associado":
 			entry["associado"] = (row.get("associado") or "").strip() or None
 			entry["responsavel"] = None
+			if entry["associado"]:
+				# Resolve no servidor para garantir o id@escoteiros quando houver,
+				# em vez de confiar no e-mail enviado pelo client.
+				entry["email"] = _associado_email(entry["associado"]) or entry["email"]
 		elif tipo_pessoa == "Responsavel":
 			entry["responsavel"] = (row.get("responsavel") or "").strip() or None
 			entry["associado"] = None

--- a/gris/www/festas/festa.py
+++ b/gris/www/festas/festa.py
@@ -217,7 +217,7 @@ def _select_items_associados() -> list[dict]:
 	registros = frappe.get_all(
 		"Associado",
 		filters={"status_no_grupo": "Ativo"},
-		fields=["name", "nome_completo", "email", "telefone"],
+		fields=["name", "nome_completo", "id_escoteiros", "email", "telefone"],
 		order_by="nome_completo asc",
 	)
 	return [
@@ -225,7 +225,8 @@ def _select_items_associados() -> list[dict]:
 			"label": r.nome_completo or r.name,
 			"value": r.name,
 			"type": "item",
-			"attrs": {"data-email": r.email or "", "data-telefone": r.telefone or ""},
+			# Prioriza o id@escoteiros sobre o e-mail comum (mesma regra do backend).
+			"attrs": {"data-email": r.id_escoteiros or r.email or "", "data-telefone": r.telefone or ""},
 		}
 		for r in registros
 	]


### PR DESCRIPTION
This pull request improves how the preferred email address for "Associado" users is determined and used throughout the codebase. The main change is to consistently prioritize the `id_escoteiros` (institutional email) when available, falling back to the regular email otherwise. This logic is now enforced both on the backend and in the frontend data provided for selection.

**Preferred email handling improvements:**

- Added a new helper function `_associado_email` in `gris/api/festas/__init__.py` to centralize the logic for selecting the preferred email (`id_escoteiros` if present, otherwise `email`).
- Updated the assignment of `email_coord` in both `salvar_area` and `salvar_barraca` to use `_associado_email`, ensuring the preferred email is always used for coordinators. [[1]](diffhunk://#diff-42336687f97b7954926d794f3f1f743b4e027a6fdf8686c3984ce81310ac24d7L262-R269) [[2]](diffhunk://#diff-42336687f97b7954926d794f3f1f743b4e027a6fdf8686c3984ce81310ac24d7L403-R414)
- When saving area or barraca members of type "Associado", the system now resolves their preferred email on the server side, overriding any client-sent email to guarantee consistency. [[1]](diffhunk://#diff-42336687f97b7954926d794f3f1f743b4e027a6fdf8686c3984ce81310ac24d7R294-R297) [[2]](diffhunk://#diff-42336687f97b7954926d794f3f1f743b4e027a6fdf8686c3984ce81310ac24d7R439-R442)

**Frontend data consistency:**

- Modified `_select_items_associados` in `gris/www/festas/festa.py` to include `id_escoteiros` in the fetched fields and to set the `data-email` attribute to prioritize `id_escoteiros` over the regular email, matching the backend logic.…festas