### PR TITLE
Corrige seleção de responsáveis por tarefas em festas

### DIFF
--- a/gris/api/gestao_de_tarefas/quadros.py
+++ b/gris/api/gestao_de_tarefas/quadros.py
@@ -197,7 +197,18 @@ def bootstrap_quadro(board_name: str) -> dict[str, Any]:
 		"user_board_name": board_name,
 		"board": board,
 		"tarefas": _listar_tarefas_do_quadro(board_name),
+		"responsavel_options": _responsavel_options_do_quadro(board_name),
 	}
+
+
+def _responsavel_options_do_quadro(board_name: str) -> list[dict[str, Any]]:
+	"""Usuarios autorizados do board (equipe da festa) como opcoes de responsavel
+	para o combobox de tarefas: {user, full_name}."""
+	return [
+		{"user": membro["user"], "full_name": membro["full_name"]}
+		for membro in _serializar_membros(board_name)
+		if membro.get("user")
+	]
 
 
 @frappe.whitelist()

--- a/gris/gestao_de_tarefas/board_sync_festa.py
+++ b/gris/gestao_de_tarefas/board_sync_festa.py
@@ -127,7 +127,10 @@ def coletar_usuarios_da_festa(festa_name: str) -> dict[str, str]:
 def _resolver_email(tipo, associado, responsavel, email_direto) -> str:
 	tipo = (tipo or "").strip()
 	if tipo == "Associado" and associado:
-		email = frappe.db.get_value("Associado", associado, "email")
+		# O User (login) do associado é criado com o id@escoteiros, então
+		# priorizamos esse e-mail; senão cai para o e-mail comum.
+		dados = frappe.db.get_value("Associado", associado, ["id_escoteiros", "email"], as_dict=True) or {}
+		email = dados.get("id_escoteiros") or dados.get("email")
 	elif tipo == "Responsavel" and responsavel:
 		email = frappe.db.get_value("Responsavel", responsavel, "email")
 	else:

--- a/gris/www/festas/festa.js
+++ b/gris/www/festas/festa.js
@@ -4303,7 +4303,10 @@
 			canEdit: true,
 			onLoad: async () => {
 				const data = await callApi(METHODS.bootstrap, { board_name: board });
-				return { tarefas: data.tarefas || [] };
+				return {
+					tarefas: data.tarefas || [],
+					responsavelOptions: data.responsavel_options || [],
+				};
 			},
 			onSaveTask: async (payload) => {
 				const data = await callApi(METHODS.saveTask, { tarefa: { ...payload, board } });


### PR DESCRIPTION
This pull request enhances the management of task boards by improving how responsible users are selected and how user emails are resolved. The main changes involve exposing board member options for task assignment, updating the frontend to use these options, and refining email selection logic for associated users.

**Backend improvements for responsible user selection:**

* Added the `_responsavel_options_do_quadro` helper function in `quadros.py` to provide a list of authorized board members (with `user` and `full_name`) for use as responsible options in the UI. This is now included in the response of `bootstrap_quadro`.

**Frontend integration:**

* Updated the `onLoad` handler in `festa.js` to receive and make available the new `responsavelOptions` data for use in the task assignment combobox.

**User email resolution improvements:**

* Improved the `_resolver_email` function in `board_sync_festa.py` to prioritize the `id_escoteiros` email (login) for "Associado" users, falling back to their regular email if the login is not available.