### PR TITLE
Corrige problemas em gestão de tarefas e submissão de projetos

### DIFF
--- a/gris/api/gestao_de_tarefas/minhas_tarefas.py
+++ b/gris/api/gestao_de_tarefas/minhas_tarefas.py
@@ -247,8 +247,6 @@ def _normalize_dates(payload: dict[str, Any], previous_status: str = "") -> dict
 def _assert_payload(payload: dict[str, Any]) -> None:
 	if not (payload.get("descricao") or "").strip():
 		frappe.throw(_("Informe o titulo da tarefa."))
-	if not payload.get("prazo"):
-		frappe.throw(_("Informe o prazo da tarefa."))
 	status = (payload.get("status") or "Nao iniciado").strip()
 	if status not in TASK_STATUS_OPTIONS:
 		frappe.throw(_("Status da tarefa invalido."))

--- a/gris/gestao_de_projetos/doctype/projeto/projeto.py
+++ b/gris/gestao_de_projetos/doctype/projeto/projeto.py
@@ -18,6 +18,10 @@ from gris.gris.doctype.gestao_de_tarefas.gestao_de_tarefas import (
 	TASK_FIELDS,
 	TASK_STATUS_OPTIONS,
 )
+from gris.utils.contato import (
+	_get_associado_payload,
+	_get_responsavel_payload,
+)
 from gris.utils.contato import get_contato_pessoa as _shared_get_contato_pessoa
 from gris.utils.whatsapp import enviar_mensagem_formatada, enviar_texto
 

--- a/gris/gris/doctype/gestao_de_tarefas/gestao_de_tarefas.json
+++ b/gris/gris/doctype/gestao_de_tarefas/gestao_de_tarefas.json
@@ -65,8 +65,7 @@
   {
    "fieldname": "prazo",
    "fieldtype": "Date",
-   "label": "Prazo",
-   "reqd": 1
+   "label": "Prazo"
   },
   {
    "fieldname": "data_entrega",

--- a/gris/public/design_system/components/composed/kanban-tarefas.html.jinja
+++ b/gris/public/design_system/components/composed/kanban-tarefas.html.jinja
@@ -105,7 +105,7 @@
                         {"value": "Cancelado",     "label": "Cancelado"}
                     ]) }}
                 {% endcall %}
-                {% call _field(label="Prazo *") %}
+                {% call _field(label="Prazo") %}
                     <div data-kanban-prazo-wrapper></div>
                 {% endcall %}
             </div>

--- a/gris/public/design_system/js/components/kanban-tarefas.js
+++ b/gris/public/design_system/js/components/kanban-tarefas.js
@@ -820,11 +820,6 @@
                 return;
             }
             const prazoWrapper = this._dlg("[data-kanban-prazo-wrapper]");
-            if (!payload.prazo) {
-                if (prazoWrapper) prazoWrapper.classList.add("is-invalid");
-                showToast("Informe o prazo da tarefa.", "error");
-                return;
-            }
             if (prazoWrapper) prazoWrapper.classList.remove("is-invalid");
 
             this.saving = true;

--- a/gris/www/gestao_tarefas/tarefas.js
+++ b/gris/www/gestao_tarefas/tarefas.js
@@ -366,7 +366,10 @@
             onLoad: async () => {
                 const args = modo === "projeto" ? { board_name: boardName } : {};
                 const data = await callApi(methods.bootstrap, args);
-                return { tarefas: data.tarefas || [] };
+                return {
+                    tarefas: data.tarefas || [],
+                    responsavelOptions: data.responsavel_options || [],
+                };
             },
             onSaveTask: async (payload) => {
                 const taskPayload = modo === "projeto"


### PR DESCRIPTION
This pull request removes the requirement for the "Prazo" (deadline) field when creating or editing tasks, updating both backend validation and frontend UI to reflect this change. Additionally, it introduces the passing of `responsavelOptions` (responsible person options) to the frontend for task management.

**Task deadline ("Prazo") requirement removed:**

* Removed the backend validation that enforced the "Prazo" field as required in `_assert_payload` in `minhas_tarefas.py`.
* Made the "Prazo" field non-required in the `gestao_de_tarefas.json` DocType definition.
* Updated the Kanban UI to remove the required asterisk from the "Prazo" label in `kanban-tarefas.html.jinja`.
* Removed frontend validation for the "Prazo" field in `kanban-tarefas.js`, so tasks can be saved without a deadline.

**Task responsible person options:**

* Updated the task board bootstrap logic to include `responsavelOptions` in the data returned to the frontend in `tarefas.js`.

**Code organization:**

* Added missing utility imports for contact payload helpers in `projeto.py`.