### PR TITLE
Corrige permissões

### DIFF
--- a/gris/api/recepcao.py
+++ b/gris/api/recepcao.py
@@ -37,9 +37,14 @@ def _anonimizar_user(user_email):
 		frappe.db.delete("Gestao de Tarefas", {"board": board})
 		frappe.delete_doc("Board", board, ignore_permissions=True)
 
-	# Renomeia o login para um identificador anônimo (atualiza links que apontam ao User)
+	# Renomeia o login para um identificador anônimo (atualiza os links que apontam
+	# ao User). Usa o rename_doc interno: o wrapper público `frappe.rename_doc` não
+	# expõe `ignore_permissions`, necessário aqui porque a recepção não tem permissão
+	# de escrita em User.
+	from frappe.model.rename_doc import rename_doc
+
 	anon_email = f"desativado-{frappe.generate_hash(length=10)}@anonimizado.invalid"
-	frappe.rename_doc("User", user_email, anon_email, force=True, ignore_permissions=True)
+	rename_doc("User", user_email, anon_email, force=True, ignore_permissions=True)
 
 	# Limpa os dados pessoais remanescentes e desativa o acesso
 	frappe.db.set_value(


### PR DESCRIPTION
This pull request makes a small but important change to the user anonymization logic in `gris/api/recepcao.py`. It switches from using the public `frappe.rename_doc` function to the internal `rename_doc` function to allow the use of the `ignore_permissions` parameter, which is necessary because the reception process does not have write permissions on `User`.

- Changed to use the internal `rename_doc` from `frappe.model.rename_doc` instead of the public `frappe.rename_doc`, enabling the use of `ignore_permissions=True` when renaming a user for anonymization.