### PR TITLE
Fix/party units

### DIFF
--- a/gris/api/festas/__init__.py
+++ b/gris/api/festas/__init__.py
@@ -774,6 +774,7 @@ def _hydrate_compra(doc) -> dict:
 		"cotacao_escolhida_valor": flt(doc.cotacao_escolhida_valor),
 		"valor_total_compra": flt(doc.valor_total_compra),
 		"valor_individual_realizado": flt(doc.valor_individual_realizado),
+		"quantidade_cotacao_realizada": flt(doc.quantidade_cotacao_realizada),
 		"unidade_medida_realizado": doc.unidade_medida_realizado or "unidade",
 		"quantidade_realizada": flt(doc.quantidade_realizada),
 		"valor_total_realizado": flt(doc.valor_total_realizado),
@@ -1030,6 +1031,9 @@ def excluir_contratacao(contratacao_name: str, festa_name: str) -> dict:
 def _apply_compra_realizado(doc, dados: dict) -> None:
 	doc.valor_individual_realizado = _as_non_negative_float(
 		dados.get("valor_individual_realizado", 0), "Valor individual realizado"
+	)
+	doc.quantidade_cotacao_realizada = _as_non_negative_float(
+		dados.get("quantidade_cotacao_realizada", 0), "Quantidade da cotação realizada"
 	)
 	doc.unidade_medida_realizado = _validate_unidade(
 		dados.get("unidade_medida_realizado") or "unidade", "Unidade realizada"

--- a/gris/api/festas/lista_compras.py
+++ b/gris/api/festas/lista_compras.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2026, Grupo Escoteiro Professora Inah de Mello - 47/SP and contributors
+# For license information, please see license.txt
+
+"""Lista de compras da festa em PDF.
+
+Documento de apoio (não oficial) para levar ao mercado: itens previstos com
+cotação de compra real escolhida, ordenados por nome, com um checkbox para
+marcação manual do que já foi comprado. O pipeline espelha o do relatório da
+festa (gris/api/festas/relatorio.py): Jinja + WeasyPrint, bytes devolvidos via
+`frappe.local.response`.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import os
+
+import frappe
+from frappe.utils import flt, format_date, get_fullname, today
+
+from gris.festas.utils.unidades import converter
+
+_TEMPLATE = "templates/pages/lista_compras_pdf.html"
+
+
+def _logo_uel_data_uri() -> str:
+	"""Logo da UEL como data-URI PNG (sem contorno: o hero fica sobre fundo claro)."""
+	from gris.festas.utils.convite_qr import _carregar_logo
+
+	logo = _carregar_logo()
+	if logo is None:
+		return ""
+	buf = io.BytesIO()
+	logo.save(buf, format="PNG")
+	return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
+
+
+def _render_pdf_template(rel_path: str, ctx: dict) -> str:
+	path = os.path.join(frappe.get_app_path("gris"), rel_path)
+	with open(path, encoding="utf-8") as fh:
+		return frappe.render_template(fh.read(), ctx)
+
+
+def _fmt_num(val) -> str:
+	"""Formata número no padrão pt-BR (até 2 casas, sem zeros à direita).
+
+	Espelha `fmtNum` de festa.js (Intl pt-BR, maximumFractionDigits: 2).
+	"""
+	n = round(flt(val), 2)
+	if n == int(n):
+		return f"{int(n):,}".replace(",", ".")
+	inteiro, _, dec = f"{n:,.2f}".partition(".")
+	dec = dec.rstrip("0")
+	inteiro = inteiro.replace(",", ".")
+	return f"{inteiro},{dec}" if dec else inteiro
+
+
+def build_lista_compras_payload(festa_name: str) -> dict:
+	"""Monta o contexto do PDF da lista de compras.
+
+	Inclui apenas itens previstos com cotação escolhida de compra real
+	(`escolhida=1, doacao=0`); itens sem cotação ou doados ficam de fora.
+	"""
+	doc = frappe.get_doc("Festa", festa_name)
+
+	compras = frappe.get_all(
+		"Compra Festa",
+		filters={"festa": festa_name, "previsto": 1},
+		fields=["name", "nome_item", "unidade_compra", "quantidade_compra_final"],
+	)
+
+	rows: list[dict] = []
+	if compras:
+		nomes = [c.name for c in compras]
+		cotacoes = frappe.get_all(
+			"Cotacao Compra Festa",
+			filters={
+				"parenttype": "Compra Festa",
+				"parent": ["in", nomes],
+				"escolhida": 1,
+				"doacao": 0,
+			},
+			fields=["parent", "quantidade", "unidade_medida"],
+		)
+		cot_por_compra = {c.parent: c for c in cotacoes}
+
+		for c in compras:
+			cot = cot_por_compra.get(c.name)
+			if not cot:
+				continue
+			unidade_compra = c.unidade_compra or "unidade"
+			unidade_cot = cot.unidade_medida or "unidade"
+			# qtdPacote: quantidade da cotação convertida para a unidade de compra.
+			# Unidades incompatíveis (mesma lógica de convertUnit no festa.js) → 0.
+			try:
+				qtd_pacote = converter(flt(cot.quantidade), unidade_cot, unidade_compra)
+			except Exception:
+				qtd_pacote = 0.0
+			total = flt(c.quantidade_compra_final) * qtd_pacote
+			# Especificação completa: nome + quantidade da cotação + unidade da cotação.
+			especificacao = " ".join(
+				p for p in [c.nome_item, _fmt_num(cot.quantidade), unidade_cot] if p
+			)
+			rows.append(
+				{
+					"especificacao": especificacao,
+					"quantidade": _fmt_num(c.quantidade_compra_final),
+					"total": f"{_fmt_num(total)} {unidade_compra}".strip(),
+					"_ordem": (c.nome_item or "").casefold(),
+				}
+			)
+		rows.sort(key=lambda r: r["_ordem"])
+
+	nome_festa = doc.nome_festa or doc.name
+	usuario = get_fullname()
+	data_hoje = format_date(today(), "dd/MM/yyyy")
+	uel = frappe.get_cached_doc("Definicao da UEL")
+	return {
+		"nome_festa": nome_festa,
+		"data_festa": format_date(doc.data, "dd/MM/yyyy") if doc.data else "",
+		"rows": rows,
+		"uel_logo": _logo_uel_data_uri(),
+		"uel_tipo": uel.get("tipo_uel") or "",
+		"uel_nome": uel.get("nome_da_uel") or "",
+		"footer_text": f"Dados da {nome_festa} extraídos por {usuario} no dia {data_hoje}",
+	}
+
+
+def _gerar_lista_compras_pdf_bytes(festa_name: str) -> bytes:
+	from weasyprint import HTML
+
+	ctx = build_lista_compras_payload(festa_name)
+	html = _render_pdf_template(_TEMPLATE, ctx)
+	base_url = frappe.get_app_path("gris", "public") + os.sep
+	return HTML(string=html, base_url=base_url).write_pdf()
+
+
+@frappe.whitelist()
+def download_lista_compras_pdf(festa_name: str) -> None:
+	"""Gera e disponibiliza a lista de compras da festa em PDF (documento de apoio)."""
+	if not festa_name:
+		frappe.throw("Parâmetro 'festa_name' obrigatório.", frappe.ValidationError)
+	if not frappe.has_permission("Festa", "read", festa_name):
+		frappe.throw("Sem permissão para acessar esta festa.", frappe.PermissionError)
+
+	nome_festa = frappe.db.get_value("Festa", festa_name, "nome_festa") or festa_name
+	frappe.local.response.filename = f"lista-compras-{frappe.scrub(nome_festa)}.pdf"
+	frappe.local.response.filecontent = _gerar_lista_compras_pdf_bytes(festa_name)
+	frappe.local.response.type = "pdf"

--- a/gris/festas/doctype/compra_festa/compra_festa.json
+++ b/gris/festas/doctype/compra_festa/compra_festa.json
@@ -39,6 +39,7 @@
   "usos_em_produto",
   "realizado_section",
   "valor_individual_realizado",
+  "quantidade_cotacao_realizada",
   "unidade_medida_realizado",
   "quantidade_realizada",
   "valor_total_realizado",
@@ -245,6 +246,12 @@
    "fieldname": "valor_individual_realizado",
    "fieldtype": "Currency",
    "label": "Valor Individual Realizado"
+  },
+  {
+   "fieldname": "quantidade_cotacao_realizada",
+   "fieldtype": "Float",
+   "label": "Quantidade da Cotação Realizada",
+   "non_negative": 1
   },
   {
    "default": "unidade",

--- a/gris/templates/pages/lista_compras_pdf.html
+++ b/gris/templates/pages/lista_compras_pdf.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+	<meta charset="utf-8" />
+	<title>Lista de compras — {{ nome_festa }}</title>
+	<style>
+		/* ─────────── Fonte de marca (Figtree variável, local) ─────────── */
+		@font-face {
+			font-family: "Figtree"; font-style: normal; font-weight: 300 900;
+			src: url("design_system/fonts/figtree/figtree-latin-wght-normal.woff2") format("woff2");
+		}
+
+		/* ─────────── Tokens (derivados do tema shadcn do Portal) ─────────── */
+		/* Apenas cores de texto: var() resolve em `color` (não em background/border). */
+		:root {
+			--ink:   #1E1B4B;
+			--fg:    #14161C;
+			--muted: #67787C;
+		}
+
+		/* ─────────── Página ─────────── */
+		/* Rodapé por página: texto vem de `string-set: footerinfo` (elemento oculto
+		   no fluxo) — evita quebrar o CSS com nome de festa contendo aspas. O número
+		   da página usa `counter(page)` (confiável no WeasyPrint 59). Cores em hex. */
+		@page {
+			size: A4;
+			margin: 16mm 14mm 18mm 14mm;
+			@bottom-left { content: string(footerinfo);
+				font-family: "Figtree", sans-serif; font-size: 8pt; font-weight: 500;
+				color: #8a90a2; vertical-align: middle; }
+			@bottom-right { content: counter(page);
+				font-family: "Figtree", sans-serif; font-size: 9pt; font-weight: 700;
+				color: #8a90a2; vertical-align: middle; }
+		}
+
+		html, body { margin: 0; padding: 0; }
+		body { font-family: "Figtree", "Helvetica Neue", Helvetica, Arial, sans-serif;
+			color: var(--fg); font-size: 10pt; line-height: 1.45; -weasy-hyphens: none; }
+
+		/* Elemento oculto que alimenta o rodapé de todas as páginas. */
+		.footer-src { display: block; height: 0; overflow: hidden; font-size: 0;
+			string-set: footerinfo content(); }
+
+		/* ─────────── Hero (logo + UEL) ─────────── */
+		/* inline-block (não flex): o flex cross-size do WeasyPrint 59 é instável. */
+		.hero { padding-bottom: 3.5mm; margin-bottom: 6mm;
+			border-bottom: 1pt solid #CFD6DF; text-align: center; }
+		.hero__logo { height: 16mm; width: auto; vertical-align: middle;
+			margin-right: 4mm; }
+		.hero__uel { display: inline-block; vertical-align: middle;
+			font-size: 14pt; font-weight: 800; color: var(--ink);
+			letter-spacing: -.2px; }
+
+		/* ─────────── Cabeçalho do documento ─────────── */
+		.title { font-size: 22pt; font-weight: 800; color: var(--ink);
+			letter-spacing: -.4px; margin: 0; }
+		.subtitle { font-size: 11pt; font-weight: 600; color: var(--muted);
+			margin: 2mm 0 0; }
+
+		/* ─────────── Aviso ─────────── */
+		/* Hex literal: var() não pinta background/border no WeasyPrint 59. */
+		.aviso { margin: 5mm 0 6mm; padding: 3.5mm 4mm; border-radius: 8px;
+			background-color: #FFF8E6; border: 1pt solid #F2D98A;
+			color: #7A5A00; font-size: 9pt; line-height: 1.4; }
+		.aviso strong { font-weight: 700; }
+
+		/* ─────────── Tabela ─────────── */
+		/* NB: WeasyPrint 59 não pinta `background` com var() em células de tabela
+		   (th/td) — cores em hex literal para a zebra funcionar. */
+		table { width: 100%; border-collapse: collapse; font-size: 10pt; }
+		/* Repete o cabeçalho da tabela em cada página. */
+		thead { display: table-header-group; }
+		/* Cabeçalho sem fundo: apenas negrito + linha de separação dos dados. */
+		thead th { color: #1E1B4B; font-weight: 700;
+			text-align: left; padding: 1.6mm 3mm; font-size: 9pt;
+			text-transform: uppercase; letter-spacing: .3px;
+			border-bottom: 1.5pt solid #1E1B4B; }
+		thead th.num { text-align: right; }
+		thead th.check { text-align: center; width: 22mm; }
+		tbody tr { page-break-inside: avoid; }
+		tbody td { padding: 1.3mm 3mm; border-bottom: 1px solid #CFD6DF;
+			vertical-align: middle; }
+		/* Zebra: linhas pares em cinza claro (economiza tinta na impressão). */
+		tbody tr:nth-child(even) td { background-color: #F0F0F0; }
+		td.num { text-align: right; white-space: nowrap; }
+		td.check { text-align: center; }
+		.especificacao { font-weight: 600; color: #1E1B4B; }
+
+		/* Checkbox vazio impresso (quadrado com borda). */
+		.box { display: inline-block; width: 3.2mm; height: 3.2mm; border: 1pt solid #4a5568;
+			border-radius: 1.5px; vertical-align: middle; }
+
+		.empty { color: var(--muted); font-style: italic; margin: 8mm 0; text-align: center; }
+	</style>
+</head>
+<body>
+	<span class="footer-src">{{ footer_text }}</span>
+
+	{% set uel_str = (uel_tipo ~ " " ~ uel_nome) | trim %}
+	{% if uel_logo or uel_str %}
+	<header class="hero">
+		{% if uel_logo %}<img class="hero__logo" src="{{ uel_logo }}" alt="Logo da UEL" />{% endif %}
+		{% if uel_str %}<span class="hero__uel">{{ uel_str }}</span>{% endif %}
+	</header>
+	{% endif %}
+
+	<h1 class="title">Lista de compras</h1>
+	<p class="subtitle">{{ nome_festa }}{% if data_festa %} • {{ data_festa }}{% endif %}</p>
+
+	<div class="aviso">
+		<strong>Documento de apoio.</strong> Esta lista serve apenas para auxiliar a compra.
+		Os dados oficiais de compra devem ser inseridos no Gris.
+	</div>
+
+	{% if rows %}
+	<table>
+		<thead>
+			<tr>
+				<th>Item</th>
+				<th class="num">Quantidade de compra</th>
+				<th class="num">Total</th>
+				<th class="check">Comprado</th>
+			</tr>
+		</thead>
+		<tbody>
+			{% for row in rows %}
+			<tr>
+				<td class="especificacao">{{ row.especificacao }}</td>
+				<td class="num">{{ row.quantidade }}</td>
+				<td class="num">{{ row.total }}</td>
+				<td class="check"><span class="box"></span></td>
+			</tr>
+			{% endfor %}
+		</tbody>
+	</table>
+	{% else %}
+	<p class="empty">Nenhum item com cotação escolhida para comprar.</p>
+	{% endif %}
+</body>
+</html>

--- a/gris/templates/pages/lista_compras_pdf.html
+++ b/gris/templates/pages/lista_compras_pdf.html
@@ -60,8 +60,8 @@
 		/* ─────────── Aviso ─────────── */
 		/* Hex literal: var() não pinta background/border no WeasyPrint 59. */
 		.aviso { margin: 5mm 0 6mm; padding: 3.5mm 4mm; border-radius: 8px;
-			background-color: #FFF8E6; border: 1pt solid #F2D98A;
-			color: #7A5A00; font-size: 9pt; line-height: 1.4; }
+			background-color: #EEF2FF; border: 1pt solid #C7D2FE;
+			color: #3730A3; font-size: 9pt; line-height: 1.4; }
 		.aviso strong { font-weight: 700; }
 
 		/* ─────────── Tabela ─────────── */

--- a/gris/www/festas/festa.css
+++ b/gris/www/festas/festa.css
@@ -115,6 +115,45 @@
 	margin: 0;
 }
 
+/* ─── KPIs de convites ────────────────────────────────────────────────── */
+
+.festa-kpi-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+	gap: 1rem;
+	margin: 0;
+}
+
+.festa-kpi-item {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+	padding: 1rem;
+	border: 1px solid var(--border);
+	border-radius: var(--radius);
+	background: var(--card);
+}
+
+.festa-kpi-label {
+	font-size: 0.75rem;
+	font-weight: 500;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: var(--muted-foreground);
+}
+
+.festa-kpi-value {
+	font-size: var(--text-2xl);
+	line-height: 1.2;
+	font-weight: 600;
+	color: var(--foreground);
+}
+
+.festa-kpi-hint {
+	font-size: 0.75rem;
+	color: var(--muted-foreground);
+}
+
 /* ─── Estimativas grid ────────────────────────────────────────────────── */
 
 .festa-estimativas-grid {
@@ -649,6 +688,18 @@
 .festa-convites-chart-toggle [aria-pressed="true"] {
 	background: var(--primary);
 	color: var(--primary-foreground);
+}
+
+.festa-convites-toggle-wrap {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+}
+
+.festa-convites-toggle-wrap .btn-group [aria-pressed="true"] {
+	background: var(--primary);
+	color: var(--primary-foreground);
+	border-color: var(--primary);
 }
 
 .dialog-convites-config > div {

--- a/gris/www/festas/festa.css
+++ b/gris/www/festas/festa.css
@@ -72,6 +72,12 @@
 	margin-bottom: 1rem;
 }
 
+.festa-card__header-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+}
+
 .festa-card__title {
 	font-size: 1rem;
 	font-weight: 600;

--- a/gris/www/festas/festa.css
+++ b/gris/www/festas/festa.css
@@ -493,8 +493,38 @@
 	min-width: 11rem;
 }
 
+/* Opções de unidade indisponíveis (não conversíveis para a unidade geral):
+   o Basecoat as marca com pointer-events:none, o que impediria a tooltip de
+   aparecer no hover. Reabilitamos o ponteiro apenas para exibir a tooltip
+   (atributo title) — o clique continua bloqueado pelo JS do componente, que
+   ignora opções com aria-disabled. */
+.festa-edit-table .select [data-popover] [role="option"][aria-disabled="true"] {
+	pointer-events: auto;
+	cursor: not-allowed;
+}
+
 .festa-edit-table th {
 	white-space: nowrap;
+}
+
+/* Ícone de informação ao lado do rótulo de um campo (ex.: unidade de medida
+   base). Fica alinhado ao texto, com cor suave e cursor de ajuda. */
+.festa-field-info-icon {
+	display: inline-block;
+	vertical-align: -0.15em;
+	margin-left: 0.25rem;
+	color: var(--color-muted-foreground);
+	cursor: help;
+}
+
+/* Tooltip do Basecoat com frase longa: por padrão o componente usa uma única
+   linha (white-space: nowrap) e trunca com reticências. Aqui permitimos a
+   quebra de linha para o texto explicativo aparecer por completo. */
+.festa-info-tooltip[data-tooltip]::before {
+	white-space: normal;
+	width: max-content;
+	max-width: 16rem;
+	text-overflow: clip;
 }
 
 .festa-edit-table td {

--- a/gris/www/festas/festa.html
+++ b/gris/www/festas/festa.html
@@ -556,6 +556,17 @@ window._festaData = {
 	<div id="convites-config-summary" class="festa-info-grid"></div>
 	{% endcall %}
 
+	{# Seção — KPIs de desempenho de vendas #}
+	{% call card(attrs={"class": "festa-card"}) %}
+	<div class="festa-card__header">
+		<div>
+			<h2 class="festa-card__title">Desempenho de vendas</h2>
+			<p class="festa-card__subtitle">Convites vendidos, receita arrecadada e taxa frente à expectativa do cenário.</p>
+		</div>
+	</div>
+	<div id="convites-kpis" class="festa-kpi-grid"></div>
+	{% endcall %}
+
 	{# Seção — Gráfico de barras (qtd/valor por opção) #}
 	{% call card(attrs={"class": "festa-card"}) %}
 	<div class="festa-card__header">
@@ -581,6 +592,7 @@ window._festaData = {
 			</div>
 		</div>
 		<div id="chart-convites-por-ramo" class="festa-convites-chart"></div>
+		<div id="convites-ramo-meta-table" class="festa-cenarios-wrap"></div>
 		{% endcall %}
 	</div>
 
@@ -591,9 +603,15 @@ window._festaData = {
 			<h2 class="festa-card__title">Convites vendidos por dia</h2>
 			<p class="festa-card__subtitle">Tendência diária da venda de convites pagos.</p>
 		</div>
-		<div class="festa-convites-chart-toggle">
-			<button type="button" class="btn-sm-outline" data-chart="linha" data-mode="total" aria-pressed="true">Total</button>
-			<button type="button" class="btn-sm-outline" data-chart="linha" data-mode="por_opcao" aria-pressed="false">Por convite</button>
+		<div class="festa-convites-toggle-wrap">
+			<div class="btn-group" role="group" aria-label="Modo de série">
+				<button type="button" class="btn-sm-outline" data-chart="linha" data-mode="total" aria-pressed="true">Total</button>
+				<button type="button" class="btn-sm-outline" data-chart="linha" data-mode="por_opcao" aria-pressed="false">Por convite</button>
+			</div>
+			<div class="btn-group" role="group" aria-label="Acumulação">
+				<button type="button" class="btn-sm-outline" data-chart="linha-acum" data-mode="diario" aria-pressed="true">Diário</button>
+				<button type="button" class="btn-sm-outline" data-chart="linha-acum" data-mode="acumulado" aria-pressed="false">Acumulado</button>
+			</div>
 		</div>
 	</div>
 	<div id="chart-convites-linha" class="festa-convites-chart"></div>

--- a/gris/www/festas/festa.html
+++ b/gris/www/festas/festa.html
@@ -1776,9 +1776,12 @@ window._festaData = {
 		<div class="festa-compra-section" data-fechamento-block="orcamento" hidden>
 			<h3 class="festa-equipe-title">Orçamento</h3>
 			<dl class="festa-info-grid">
-				<div><dt>Valor individual</dt><dd id="fechamento-compra-orc-individual">—</dd></div>
-				<div><dt>Quantidade (cenário)</dt><dd id="fechamento-compra-orc-qtd">—</dd></div>
-				<div><dt>Valor total</dt><dd id="fechamento-compra-orc-total">—</dd></div>
+				<div><dt>Valor cotado</dt><dd id="fechamento-compra-orc-valor">—</dd></div>
+				<div><dt>Quantidade do valor cotado</dt><dd id="fechamento-compra-orc-cotqtd">—</dd></div>
+				<div><dt>Valor unitário cotado</dt><dd id="fechamento-compra-orc-individual">—</dd></div>
+				<div><dt>Quantidade de compra prevista</dt><dd id="fechamento-compra-orc-qtd">—</dd></div>
+				<div><dt>Total de compra previsto</dt><dd id="fechamento-compra-orc-totalqtd">—</dd></div>
+				<div><dt>Valor total gasto previsto</dt><dd id="fechamento-compra-orc-total">—</dd></div>
 				<div><dt>Fornecedor</dt><dd id="fechamento-compra-orc-fornecedor">—</dd></div>
 			</dl>
 		</div>
@@ -1786,21 +1789,34 @@ window._festaData = {
 		{# Realizado — inputs #}
 		<div class="festa-compra-section" data-fechamento-block="realizado">
 			<h3 class="festa-equipe-title">Realizado</h3>
+			<div class="festa-table-scroll">
+				<table class="festa-table festa-edit-table">
+					<thead>
+						<tr>
+							<th>Fornecedor</th>
+							<th>Valor</th>
+							<th>Quantidade</th>
+							<th>Unidade</th>
+							<th>Valor unitário</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td><input class="input festa-compact-input" id="fechamento-compra-real-fornecedor" autocomplete="off" placeholder="Fornecedor"></td>
+							<td>{{ currency_input(id="fechamento-compra-real-valor", attrs={"class": "festa-compact-input"}) }}</td>
+							<td><input class="input festa-compact-input" id="fechamento-compra-real-cotqtd" type="text" inputmode="decimal" data-numeric-input placeholder="0"></td>
+							<td>{{ select(id="fechamento-compra-real-unidade", name="fechamento-compra-real-unidade", items=unidades_items or [], selected="unidade", trigger_attrs={"class": "w-full"}) }}</td>
+							<td class="text-sm text-muted-foreground" id="fechamento-compra-real-valor-unitario">—</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
 			<div class="festa-dialog-form festa-compra-form-grid">
-				{% call field(label="Valor individual") %}
-					{{ currency_input(id="fechamento-compra-real-individual") }}
-				{% endcall %}
-				{% call field(label="Unidade de medida") %}
-					{{ select(id="fechamento-compra-real-unidade", name="fechamento-compra-real-unidade", items=unidades_items or [], selected="unidade", trigger_attrs={"class": "w-full"}) }}
-				{% endcall %}
-				{% call field(label="Quantidade") %}
+				{% call field(label="Quantidade de compra") %}
 					{{ input(attrs={"id": "fechamento-compra-real-qtd", "inputmode": "decimal", "data-numeric-input": "1", "placeholder": "0"}) }}
 				{% endcall %}
-				{% call field(label="Valor total") %}
+				{% call field(label="Valor total gasto") %}
 					{{ currency_input(id="fechamento-compra-real-total") }}
-				{% endcall %}
-				{% call field(label="Fornecedor") %}
-					{{ input(attrs={"id": "fechamento-compra-real-fornecedor", "autocomplete": "off", "placeholder": "Fornecedor"}) }}
 				{% endcall %}
 			</div>
 			{% call field(label="Observações") %}

--- a/gris/www/festas/festa.html
+++ b/gris/www/festas/festa.html
@@ -352,16 +352,26 @@ window._festaData = {
 			<h2 class="festa-card__title">Compras</h2>
 			<p class="festa-card__subtitle">Itens planejados para compra na festa.</p>
 		</div>
-		{% if can_edit %}
-		<button
-			type="button"
-			class="btn-sm-outline"
-			data-action="add-compra"
-		>
-			{{ lucide_icon("plus", size="sm") }}
-			<span>Adicionar compra</span>
-		</button>
-		{% endif %}
+		<div class="festa-card__header-actions">
+			<button
+				type="button"
+				class="btn-sm-outline"
+				data-action="gerar-lista-compras"
+			>
+				{{ lucide_icon("list-checks", size="sm") }}
+				<span>Gerar lista de compras</span>
+			</button>
+			{% if can_edit %}
+			<button
+				type="button"
+				class="btn-sm-outline"
+				data-action="add-compra"
+			>
+				{{ lucide_icon("plus", size="sm") }}
+				<span>Adicionar compra</span>
+			</button>
+			{% endif %}
+		</div>
 	</div>
 	<div id="compras-table-container"></div>
 	{% endcall %}

--- a/gris/www/festas/festa.html
+++ b/gris/www/festas/festa.html
@@ -1,5 +1,5 @@
 {% extends "templates/web_sidebar_base.html" %}
-{% from "public/design_system/components/composed/basecoat-composed.html.jinja" import card, field, input, textarea, empty, badge, switch %}
+{% from "public/design_system/components/composed/basecoat-composed.html.jinja" import card, field, input, textarea, empty, badge, switch, tooltip %}
 {% from "public/design_system/components/composed/file-upload.html.jinja" import file_upload %}
 {% from "public/design_system/components/generated/tabs.html.jinja" import tabs %}
 {% from "public/design_system/components/generated/dialog.html.jinja" import dialog %}
@@ -1559,7 +1559,12 @@ window._festaData = {
 					trigger_attrs={"class": "w-full"}
 				) }}
 			{% endcall %}
-			{% call field(label="Unidade de medida") %}
+			{% call field(label="Unidade de medida " ~ tooltip(
+				lucide_icon("info", size="sm", class_name="festa-field-info-icon"),
+				"Escolha a unidade de medida base do produto. Apenas para referência — será usada para apresentar a lista de compras.",
+				side="top",
+				attrs={"class": "festa-info-tooltip"}
+			)) %}
 				{{ select(
 					id="compra-unidade",
 					name="compra-unidade",
@@ -1600,10 +1605,16 @@ window._festaData = {
 					</thead>
 					<tbody>
 						<tr>
-							<td class="festa-cenarios-label">Qtd sugerida</td>
+							<td class="festa-cenarios-label">Cotações a comprar</td>
 							<td id="compra-cen-qtd-min">—</td>
 							<td id="compra-cen-qtd-int">—</td>
 							<td id="compra-cen-qtd-max">—</td>
+						</tr>
+						<tr>
+							<td class="festa-cenarios-label">Total</td>
+							<td id="compra-cen-total-min">—</td>
+							<td id="compra-cen-total-int">—</td>
+							<td id="compra-cen-total-max">—</td>
 						</tr>
 						<tr>
 							<td class="festa-cenarios-label">Valor total</td>

--- a/gris/www/festas/festa.js
+++ b/gris/www/festas/festa.js
@@ -3770,10 +3770,22 @@
 			var valorCotado = c.previsto !== false
 				? (Number(c["valor_total_" + key]) || 0)
 				: (Number(c.valor_total_compra) || 0);
+			// "Quantidade de compra" é a contagem de cotações; o total previsto na
+			// unidade geral do produto = contagem × quantidade da cotação escolhida
+			// (convertida para a unidade geral). Mesmo cálculo da aba de compras.
+			var qtd = Number(c.quantidade_compra_final) || 0;
+			var escolhida = (c.cotacoes || []).find(function (x) { return x.escolhida; });
+			var qtdPacote = 0;
+			if (escolhida && Number(escolhida.quantidade) > 0) {
+				var conv = convertUnit(Number(escolhida.quantidade), escolhida.unidade_medida || "unidade", c.unidade_compra || "unidade");
+				if (conv !== null && conv > 0) qtdPacote = conv;
+			}
+			var totalPrevisto = qtd * qtdPacote;
 			return `
 <tr>
 	<td>${escHtml(c.nome_item)}${tag}</td>
-	<td>${fmtNum(c.quantidade_compra_final)} ${escHtml(c.unidade_compra || "")}</td>
+	<td>${fmtNum(c.quantidade_compra_final)}</td>
+	<td>${fmtNum(totalPrevisto)} ${escHtml(c.unidade_compra || "")}</td>
 	<td>${fmtCurrency(valorCotado)}</td>
 	<td>${fmtCurrency(c.valor_total_realizado)}</td>
 	${detalhes}
@@ -3781,7 +3793,7 @@
 		}).join("");
 
 		var actionTh = canEdit ? "<th></th>" : "";
-		container.innerHTML = `<div class="festa-table-scroll"><table class="festa-table"><thead><tr><th>Item</th><th>Quantidade</th><th>Valor cotado</th><th>Valor gasto</th>${actionTh}</tr></thead><tbody>${rows}</tbody></table></div>`;
+		container.innerHTML = `<div class="festa-table-scroll"><table class="festa-table"><thead><tr><th>Item</th><th>Quantidade de compra</th><th>Total previsto</th><th>Valor cotado</th><th>Valor gasto</th>${actionTh}</tr></thead><tbody>${rows}</tbody></table></div>`;
 		notifyDesignSystem();
 		if (!canEdit) return;
 		container.querySelectorAll("[data-fechamento-compra]").forEach(function (btn) {
@@ -3790,12 +3802,37 @@
 	}
 
 	function setRealizadoCompra(c) {
-		document.getElementById("fechamento-compra-real-individual").value = c.valor_individual_realizado || "";
+		document.getElementById("fechamento-compra-real-fornecedor").value = c.fornecedor_realizado || "";
+		document.getElementById("fechamento-compra-real-valor").value = c.valor_individual_realizado || "";
+		document.getElementById("fechamento-compra-real-cotqtd").value = c.quantidade_cotacao_realizada || "";
 		setSelectValue("fechamento-compra-real-unidade", c.unidade_medida_realizado || "unidade", c.unidade_medida_realizado || "unidade");
 		document.getElementById("fechamento-compra-real-qtd").value = c.quantidade_realizada || "";
-		document.getElementById("fechamento-compra-real-total").value = c.valor_total_realizado || "";
-		document.getElementById("fechamento-compra-real-fornecedor").value = c.fornecedor_realizado || "";
+		var totalEl = document.getElementById("fechamento-compra-real-total");
+		totalEl.value = c.valor_total_realizado || "";
+		// O total é automático quando ainda não foi informado; ao reabrir um
+		// realizado já preenchido, preservamos o valor digitado pelo gestor.
+		totalEl.dataset.autoTotal = Number(c.valor_total_realizado) > 0 ? "0" : "1";
 		document.getElementById("fechamento-compra-real-obs").value = c.observacoes_realizado || "";
+		syncFechamentoRealizado();
+	}
+
+	// Recalcula o valor unitário exibido e, enquanto o total estiver em modo
+	// automático, o valor total gasto (= quantidade de compra × valor por pacote).
+	function syncFechamentoRealizado() {
+		var valor = parseFloat((document.getElementById("fechamento-compra-real-valor") || {}).value) || 0;
+		var cotQtd = parseFloat((document.getElementById("fechamento-compra-real-cotqtd") || {}).value) || 0;
+		var unidade = getSelectValue("fechamento-compra-real-unidade") || "unidade";
+		var unitarioEl = document.getElementById("fechamento-compra-real-valor-unitario");
+		if (unitarioEl) {
+			unitarioEl.textContent = cotQtd > 0
+				? fmtCurrency(valor / cotQtd) + " / " + unitLabel(unidade)
+				: "—";
+		}
+		var totalEl = document.getElementById("fechamento-compra-real-total");
+		if (totalEl && totalEl.dataset.autoTotal === "1") {
+			var qtdCompra = parseFloat((document.getElementById("fechamento-compra-real-qtd") || {}).value) || 0;
+			totalEl.value = qtdCompra * valor;
+		}
 	}
 
 	function openCompraFechamentoDialog(idx) {
@@ -3827,10 +3864,24 @@
 				var escolhida = (compra.cotacoes || []).find(function (x) { return x.escolhida; });
 				var valIndividual = escolhida && Number(escolhida.quantidade) > 0 && !escolhida.doacao
 					? (Number(escolhida.valor) || 0) / Number(escolhida.quantidade) : 0;
+				fechamentoSetText("fechamento-compra-orc-valor",
+					escolhida ? (escolhida.doacao ? "Doação" : fmtCurrency(escolhida.valor)) : "—");
+				fechamentoSetText("fechamento-compra-orc-cotqtd",
+					escolhida ? fmtNum(escolhida.quantidade) + " " + unitLabel(escolhida.unidade_medida || "unidade") : "—");
 				fechamentoSetText("fechamento-compra-orc-individual",
-					escolhida ? fmtCurrency(valIndividual) + " / " + (escolhida.unidade_medida || "unidade") : "—");
-				fechamentoSetText("fechamento-compra-orc-qtd",
-					fmtNum(compra["qtd_sugerida_" + key]) + " " + (compra.unidade_compra || ""));
+					escolhida ? fmtCurrency(valIndividual) + " / " + unitLabel(escolhida.unidade_medida || "unidade") : "—");
+				// Quantidade de compra = quantidade final (mesma da tabela), não a sugerida.
+				var qtdCompraFinal = Number(compra.quantidade_compra_final) || 0;
+				fechamentoSetText("fechamento-compra-orc-qtd", fmtNum(qtdCompraFinal));
+				// Total previsto = quantidade de compra × tamanho do pacote da cotação
+				// (convertido para a unidade geral do produto). Mesmo cálculo da tabela.
+				var qtdPacoteOrc = 0;
+				if (escolhida && Number(escolhida.quantidade) > 0) {
+					var convOrc = convertUnit(Number(escolhida.quantidade), escolhida.unidade_medida || "unidade", compra.unidade_compra || "unidade");
+					if (convOrc !== null && convOrc > 0) qtdPacoteOrc = convOrc;
+				}
+				fechamentoSetText("fechamento-compra-orc-totalqtd",
+					fmtNum(qtdCompraFinal * qtdPacoteOrc) + " " + (compra.unidade_compra || ""));
 				fechamentoSetText("fechamento-compra-orc-total", fmtCurrency(compra["valor_total_" + key]));
 				fechamentoSetText("fechamento-compra-orc-fornecedor", escolhida ? (escolhida.fornecedor || "—") : "—");
 			} else {
@@ -3886,7 +3937,8 @@
 
 	function collectCompraRealizado() {
 		return {
-			valor_individual_realizado: parseFloat(document.getElementById("fechamento-compra-real-individual").value) || 0,
+			valor_individual_realizado: parseFloat(document.getElementById("fechamento-compra-real-valor").value) || 0,
+			quantidade_cotacao_realizada: parseFloat(document.getElementById("fechamento-compra-real-cotqtd").value) || 0,
 			unidade_medida_realizado: getSelectValue("fechamento-compra-real-unidade") || "unidade",
 			quantidade_realizada: parseFloat(document.getElementById("fechamento-compra-real-qtd").value) || 0,
 			valor_total_realizado: parseFloat(document.getElementById("fechamento-compra-real-total").value) || 0,
@@ -4380,6 +4432,23 @@
 			fechamentoCompraUsos.push({ produto: "", quantidade_usada: 0, unidade_medida_uso: "unidade" });
 			renderFechamentoCompraUsos();
 		});
+
+		// Ao editar a cotação realizada, reativa o cálculo automático do total e
+		// recalcula valor unitário + total gasto.
+		["fechamento-compra-real-valor", "fechamento-compra-real-cotqtd", "fechamento-compra-real-qtd"].forEach(function (id) {
+			var el = document.getElementById(id);
+			if (!el) return;
+			el.addEventListener("input", function () {
+				var totalEl = document.getElementById("fechamento-compra-real-total");
+				if (totalEl) totalEl.dataset.autoTotal = "1";
+				syncFechamentoRealizado();
+			});
+		});
+		var unidadeReal = document.getElementById("fechamento-compra-real-unidade");
+		if (unidadeReal) unidadeReal.addEventListener("change", syncFechamentoRealizado);
+		// Ao digitar o total manualmente, deixa de ser automático (resposta final do gestor).
+		var totalReal = document.getElementById("fechamento-compra-real-total");
+		if (totalReal) totalReal.addEventListener("input", function () { totalReal.dataset.autoTotal = "0"; });
 
 		var btnCompra = document.getElementById("btn-fechamento-compra-salvar");
 		if (btnCompra) btnCompra.addEventListener("click", saveCompraFechamento);

--- a/gris/www/festas/festa.js
+++ b/gris/www/festas/festa.js
@@ -2760,6 +2760,7 @@
 	};
 	let convitesBarrasMode = "qtd";
 	let convitesLinhaMode = "total";
+	let convitesLinhaAcum = "diario";
 	let chartBarrasInstance = null;
 	let chartLinhaInstance = null;
 	let chartConvitesPorRamoInstance = null;
@@ -2818,6 +2819,111 @@
 			'<div><dt>Tipos cadastrados</dt><dd>' + tiposAtivos + " ativos / " + tiposTotal + " no total</dd></div>" +
 			'<div><dt>Aceita doações</dt><dd>' + doacoes + "</dd></div>" +
 			"<div><dt>Limite de vendas</dt><dd>" + data + "</dd></div>";
+	}
+
+	function expectativaPublicoCenario() {
+		const fd = window._festaData || {};
+		const mapa = {
+			"Mínimo": fd.publicoMin,
+			"Intermediário": fd.publicoIntermediario,
+			"Máximo": fd.publicoMax,
+		};
+		const cenario = convitesDashboard.cenario_simulacao || "Intermediário";
+		return { cenario: cenario, esperado: Number(mapa[cenario] || 0) };
+	}
+
+	function renderConvitesKpis() {
+		const container = document.getElementById("convites-kpis");
+		if (!container) return;
+		const totais = convitesDashboard.totais || {};
+		const qtdMap = totais.qtd_por_opcao || {};
+		const valMap = totais.valor_por_opcao || {};
+		const totalVendidos = Object.keys(qtdMap).reduce(function (s, k) {
+			return s + Number(qtdMap[k] || 0);
+		}, 0);
+		let receitaTotal = Object.keys(valMap).reduce(function (s, k) {
+			return s + Number(valMap[k] || 0);
+		}, 0);
+		if (convitesDashboard.aceitar_doacoes) {
+			receitaTotal += Number(totais.total_doacoes_valor || 0);
+		}
+		const exp = expectativaPublicoCenario();
+		const taxa = exp.esperado > 0 ? (totalVendidos / exp.esperado) * 100 : null;
+		const taxaValor = taxa === null ? "—" : taxa.toFixed(1) + "%";
+		const taxaHint = exp.esperado > 0
+			? fmtInt(totalVendidos) + " de " + fmtInt(exp.esperado) + " esperados (cenário " + escapeHtml(exp.cenario) + ")"
+			: "Defina a expectativa de público do cenário";
+		container.innerHTML =
+			'<div class="festa-kpi-item">' +
+				'<span class="festa-kpi-label">Convites vendidos</span>' +
+				'<span class="festa-kpi-value">' + fmtInt(totalVendidos) + "</span>" +
+			"</div>" +
+			'<div class="festa-kpi-item">' +
+				'<span class="festa-kpi-label">Receita arrecadada</span>' +
+				'<span class="festa-kpi-value">' + fmtMoeda(receitaTotal) + "</span>" +
+			"</div>" +
+			'<div class="festa-kpi-item">' +
+				'<span class="festa-kpi-label">Taxa vs. expectativa</span>' +
+				'<span class="festa-kpi-value">' + taxaValor + "</span>" +
+				'<span class="festa-kpi-hint">' + taxaHint + "</span>" +
+			"</div>";
+	}
+
+	function renderConvitesRamoMetaTable() {
+		const container = document.getElementById("convites-ramo-meta-table");
+		if (!container) return;
+		if (!convitesDashboard.convites_por_ramo) {
+			container.innerHTML = "";
+			return;
+		}
+		const porRamo = convitesDashboard.por_ramo || {};
+		const linhas = RAMOS_ORDEM
+			.map(function (ramo) {
+				const info = porRamo[ramo] || {};
+				return {
+					ramo: ramo,
+					vendidos: Number(info.qtd_vendida || 0),
+					meta: Number(info.qtd_esperada || 0),
+					beneficiarios: Number(info.beneficiarios_ativos || 0),
+				};
+			})
+			.filter(function (r) { return r.meta > 0 || r.vendidos > 0 || r.beneficiarios > 0; });
+		if (!linhas.length) {
+			container.innerHTML = '<p class="text-sm text-muted-foreground">Nenhuma meta por ramo definida ainda.</p>';
+			return;
+		}
+		const metaCell = function (vendidos, meta) {
+			if (meta <= 0) return "<td>—</td>";
+			const pct = (vendidos / meta) * 100;
+			const cls = pct >= 100 ? "festa-cenarios-cell--success" : "festa-cenarios-cell--danger";
+			return '<td class="' + cls + '">' + pct.toFixed(1) + "%</td>";
+		};
+		let totalVend = 0, totalMeta = 0;
+		let html = '<table class="festa-cenarios-table"><thead><tr>';
+		html += "<th>Ramo</th><th>Vendidos</th><th>Meta</th><th>% da meta</th><th>Faltam</th>";
+		html += "</tr></thead><tbody>";
+		linhas.forEach(function (r) {
+			totalVend += r.vendidos;
+			totalMeta += r.meta;
+			const faltam = Math.max(r.meta - r.vendidos, 0);
+			html += "<tr>";
+			html += '<td class="festa-cenarios-label">' + escapeHtml(r.ramo) + "</td>";
+			html += "<td>" + fmtInt(r.vendidos) + "</td>";
+			html += "<td>" + fmtInt(r.meta) + "</td>";
+			html += metaCell(r.vendidos, r.meta);
+			html += "<td>" + fmtInt(faltam) + "</td>";
+			html += "</tr>";
+		});
+		const totalFaltam = Math.max(totalMeta - totalVend, 0);
+		html += '<tr class="festa-cenarios-row--total">';
+		html += '<td class="festa-cenarios-label">Total</td>';
+		html += "<td>" + fmtInt(totalVend) + "</td>";
+		html += "<td>" + fmtInt(totalMeta) + "</td>";
+		html += metaCell(totalVend, totalMeta);
+		html += "<td>" + fmtInt(totalFaltam) + "</td>";
+		html += "</tr>";
+		html += "</tbody></table>";
+		container.innerHTML = html;
 	}
 
 	function renderConvitesBarras() {
@@ -3064,6 +3170,18 @@
 					};
 				});
 			}
+			const acumulado = convitesLinhaAcum === "acumulado";
+			if (acumulado) {
+				series = series.map(function (s) {
+					let soma = 0;
+					return Object.assign({}, s, {
+						data: (s.data || []).map(function (v) {
+							soma += Number(v || 0);
+							return soma;
+						}),
+					});
+				});
+			}
 			chartLinhaInstance.setOption({
 				aria: { enabled: true },
 				color: CHART_PALETTE,
@@ -3080,7 +3198,7 @@
 				},
 				yAxis: {
 					type: "value",
-					name: "Convites",
+					name: acumulado ? "Convites (acumulado)" : "Convites",
 					nameLocation: "middle",
 					nameGap: 40,
 					nameRotate: 90,
@@ -3472,8 +3590,10 @@
 		window._festaData.convitesDashboard = payload;
 		opcaoLocalList = (convitesDashboard.opcoes || []).slice();
 		renderConvitesConfigSummary();
+		renderConvitesKpis();
 		renderConvitesBarras();
 		renderChartConvitesPorRamo();
+		renderConvitesRamoMetaTable();
 		renderConvitesLinha();
 		renderConvitesTable();
 		renderOpcoesTable();
@@ -3482,6 +3602,8 @@
 	function initConvitesTab() {
 		opcaoLocalList = (convitesDashboard.opcoes || []).slice();
 		renderConvitesConfigSummary();
+		renderConvitesKpis();
+		renderConvitesRamoMetaTable();
 		renderConvitesTable();
 		renderOpcoesTable();
 
@@ -3532,6 +3654,15 @@
 			btn.addEventListener("click", function () {
 				convitesLinhaMode = btn.getAttribute("data-mode");
 				document.querySelectorAll('[data-chart="linha"]').forEach(function (b) {
+					b.setAttribute("aria-pressed", b === btn ? "true" : "false");
+				});
+				renderConvitesLinha();
+			});
+		});
+		document.querySelectorAll('[data-chart="linha-acum"]').forEach(function (btn) {
+			btn.addEventListener("click", function () {
+				convitesLinhaAcum = btn.getAttribute("data-mode");
+				document.querySelectorAll('[data-chart="linha-acum"]').forEach(function (b) {
 					b.setAttribute("aria-pressed", b === btn ? "true" : "false");
 				});
 				renderConvitesLinha();
@@ -3688,6 +3819,7 @@
 					Promise.all(tarefas)
 						.then(function () {
 							renderConvitesConfigSummary();
+							renderConvitesKpis();
 							renderConvitesBarras();
 							toast("Configurações salvas.", "success");
 							dlg.close();

--- a/gris/www/festas/festa.js
+++ b/gris/www/festas/festa.js
@@ -2270,6 +2270,17 @@
 
 	function initCompras() {
 		renderComprasTable();
+
+		// Disponível para todos que veem a aba (documento de apoio só de leitura),
+		// por isso é vinculado antes do early-return de canEdit.
+		document.querySelectorAll("[data-action='gerar-lista-compras']").forEach(function (btn) {
+			btn.addEventListener("click", function () {
+				var url = "/api/method/gris.api.festas.lista_compras.download_lista_compras_pdf?festa_name="
+					+ encodeURIComponent(festaName);
+				window.open(url, "_blank");
+			});
+		});
+
 		if (!canEdit) return;
 
 		document.querySelectorAll("[data-action='add-compra']").forEach(function (btn) {

--- a/gris/www/festas/festa.js
+++ b/gris/www/festas/festa.js
@@ -364,8 +364,12 @@
 	// carrega o `data-field` para que a leitura via `[data-field=...] .value`
 	// continue funcionando como nos selects nativos. O Basecoat inicializa o
 	// componente automaticamente (MutationObserver) ou via notifyDesignSystem().
+	// `optionMeta` (opcional): função value -> { disabled, title }. Opções
+	// desabilitadas recebem aria-disabled="true" (o Basecoat ignora cliques e
+	// navegação por teclado) e um atributo title para a tooltip. A opção
+	// selecionada nunca é desabilitada, para o componente não ficar inválido.
 	var _basecoatSelectSeq = 0;
-	function renderBasecoatSelect(dataField, items, selectedValue) {
+	function renderBasecoatSelect(dataField, items, selectedValue, optionMeta) {
 		_basecoatSelectSeq += 1;
 		var id = "ds-sel-" + dataField + "-" + _basecoatSelectSeq;
 		var selected = String(selectedValue == null ? "" : selectedValue);
@@ -379,7 +383,10 @@
 		var optionsHtml = items.map(function (item, idx) {
 			var value = item.value == null ? "" : String(item.value);
 			var sel = (matched && value === selected) ? ' aria-selected="true"' : "";
-			return '<div id="' + id + '-items-' + idx + '" role="option" data-value="' + escHtml(value) + '"' + sel + '>' + escHtml(item.label || value) + '</div>';
+			var meta = optionMeta ? optionMeta(value) : null;
+			var disabled = (meta && meta.disabled && value !== selected) ? ' aria-disabled="true"' : "";
+			var title = (meta && meta.title) ? ' title="' + escHtml(meta.title) + '"' : "";
+			return '<div id="' + id + '-items-' + idx + '" role="option" data-value="' + escHtml(value) + '"' + sel + disabled + title + '>' + escHtml(item.label || value) + '</div>';
 		}).join("");
 		return '<div id="' + id + '" class="select">'
 			+ '<button type="button" class="btn-outline w-full" id="' + id + '-trigger" aria-haspopup="listbox" aria-expanded="false" aria-controls="' + id + '-listbox">'
@@ -1763,6 +1770,33 @@
 		return (qtd * from.factor) / to.factor;
 	}
 
+	// Duas unidades só são compatíveis quando pertencem à mesma família
+	// (massa, volume ou unidade) e, portanto, podem ser convertidas entre si.
+	function unitsCompatible(unitA, unitB) {
+		var a = UNIT_FACTORS[unitA];
+		var b = UNIT_FACTORS[unitB];
+		return !!(a && b && a.family === b.family);
+	}
+
+	function unitLabel(value) {
+		var found = (unidadesItems || []).find(function (it) { return String(it.value) === String(value); });
+		return (found && found.label) || value;
+	}
+
+	// Fábrica de `optionMeta` para os selects de unidade da cotação e do uso em
+	// produtos: desabilita (com tooltip) toda unidade que não pode ser convertida
+	// para a unidade geral do produto.
+	function unitOptionMeta(generalUnit) {
+		return function (value) {
+			if (unitsCompatible(value, generalUnit)) return null;
+			return {
+				disabled: true,
+				title: "Indisponível: a unidade geral do produto (" + unitLabel(generalUnit)
+					+ ") não pode ser convertida para " + unitLabel(value) + ".",
+			};
+		};
+	}
+
 	function ceilPacotes(qtdTotal, qtdPacote) {
 		if (qtdPacote <= 0) return 0;
 		return Math.ceil(qtdTotal / qtdPacote);
@@ -1798,16 +1832,6 @@
 			max: window._festaData.publicoMax || 0,
 		};
 
-		// soma_uso_total: base sem multiplicador de cenário (para cálculo de sobra)
-		var somaUsoTotal = 0;
-		if (usadoEmProdutos) {
-			compraDraftUsos.forEach(function (uso) {
-				if (!uso.quantidade_usada || !uso.unidade_medida_uso) return;
-				var c = convertUnit(Number(uso.quantidade_usada), uso.unidade_medida_uso, unidadeCompra);
-				if (c !== null) somaUsoTotal += c;
-			});
-		}
-
 		var result = {};
 		["min", "intermediario", "max"].forEach(function (chave) {
 			var qtdSugerida;
@@ -1828,16 +1852,21 @@
 			}
 
 			var valorTotal = qtdPacote > 0 ? qtdSugerida * valorPacote : 0;
+			// Sobra individual:
+			//   ceil(somaCenario / qtdPacote) - somaCenario
+			// onde somaCenario = Σ (qtd utilizada × qtd do produto no cenário),
+			// e qtdSugerida já é ceil(somaCenario / qtdPacote).
 			var qtdSobra = 0;
 			if (usadoEmProdutos && qtdPacote > 0) {
-				qtdSobra = Math.max(0, qtdSugerida * qtdPacote - somaUsoTotal);
+				qtdSobra = Math.max(0, qtdSugerida * qtdPacote - somaCenario);
 			}
-			var precoUnitario = qtdPacote > 0 ? valorPacote / qtdPacote : 0;
 			result[chave] = {
 				qtd_sugerida: qtdSugerida,
+				qtd_total_compra: qtdSugerida * qtdPacote,
+				unidade_compra: unidadeCompra,
 				valor_total: valorTotal,
 				qtd_sobra_individual: qtdSobra,
-				valor_sobra: qtdSobra * precoUnitario,
+				valor_sobra: qtdSobra * valorPacote,
 			};
 		});
 		return result;
@@ -1886,10 +1915,21 @@
 			var valor = Number(c.valor_total_compra) || 0;
 			var nCot = (c.cotacoes || []).length;
 			var nUso = (c.usos_em_produto || []).length;
+			// "Quantidade de compra" é a contagem de cotações; o total na unidade
+			// geral do produto = contagem × quantidade da cotação escolhida
+			// (convertida para a unidade geral).
+			var escolhida = (c.cotacoes || []).find(function (x) { return x.escolhida; });
+			var qtdPacote = 0;
+			if (escolhida && Number(escolhida.quantidade) > 0) {
+				var conv = convertUnit(Number(escolhida.quantidade), escolhida.unidade_medida || "unidade", c.unidade_compra || "unidade");
+				if (conv !== null && conv > 0) qtdPacote = conv;
+			}
+			var total = qtd * qtdPacote;
 			return `
 <tr data-compra-idx="${i}">
 	<td>${escHtml(c.nome_item)}</td>
-	<td data-sort-value="${qtd}">${fmtNum(c.quantidade_compra_final)} ${escHtml(c.unidade_compra || "")}</td>
+	<td data-sort-value="${qtd}">${fmtNum(c.quantidade_compra_final)}</td>
+	<td data-sort-value="${total}">${fmtNum(total)} ${escHtml(c.unidade_compra || "")}</td>
 	<td data-sort-value="${valor}">${fmtCurrency(c.valor_total_compra)}</td>
 	<td data-sort-value="${nCot}"><span class="badge">${nCot}</span></td>
 	<td data-sort-value="${nUso}"><span class="badge">${nUso}</span></td>
@@ -1908,7 +1948,8 @@
 
 		var headers = [
 			{ label: "Item", sortType: "text" },
-			{ label: "Quantidade", sortType: "number" },
+			{ label: "Quantidade de compra", sortType: "number" },
+			{ label: "Total", sortType: "number" },
 			{ label: "Valor total", sortType: "number" },
 			{ label: "Cotações", sortType: "number" },
 			{ label: "Produtos", sortType: "number" },
@@ -2006,6 +2047,8 @@
 			container.innerHTML = '<p class="text-sm text-muted-foreground festa-equipe-empty">Nenhuma cotação adicionada.</p>';
 			return;
 		}
+		var unidadeGeral = getSelectValue("compra-unidade") || "unidade";
+		var metaUnidade = unitOptionMeta(unidadeGeral);
 		var rows = compraDraftCotacoes.map(function (c, idx) {
 			var valUnit = (c.quantidade > 0 && !c.doacao)
 				? (new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format((c.valor || 0) / c.quantidade)
@@ -2016,7 +2059,7 @@
 	<td><input class="input festa-compact-input" data-field="fornecedor" value="${escHtml(c.fornecedor || "")}" placeholder="Fornecedor"></td>
 	<td>${window.GrisCurrencyInput.render({ field: "valor", value: c.valor, class: "festa-compact-input" })}</td>
 	<td><input class="input festa-compact-input" data-field="quantidade" type="text" inputmode="decimal" data-numeric-input value="${escHtml(c.quantidade || "")}"></td>
-	<td>${renderNativeSelect("unidade_medida", unidadesItems, c.unidade_medida || "unidade")}</td>
+	<td>${renderBasecoatSelect("unidade_medida", unidadesItems, c.unidade_medida || "unidade", metaUnidade)}</td>
 	<td class="text-sm text-muted-foreground" data-valor-unitario>${escHtml(valUnit)}</td>
 	<td class="festa-switch-cell"><label class="switch" aria-label="Cotação escolhida"><input type="checkbox" role="switch" class="input" data-field="escolhida"${c.escolhida ? " checked" : ""}></label></td>
 	<td class="festa-switch-cell"><label class="switch" aria-label="Doação"><input type="checkbox" role="switch" class="input" data-field="doacao"${c.doacao ? " checked" : ""}></label></td>
@@ -2042,7 +2085,9 @@
 </table>
 </div>`;
 		document.dispatchEvent(new CustomEvent("gris:design-system:init"));
-		container.querySelectorAll("input, select").forEach(function (el) {
+		// Inclui ".select" para capturar o evento change que o select Basecoat
+		// dispara no próprio componente (não no input hidden interno).
+		container.querySelectorAll("input, select, .select").forEach(function (el) {
 			el.addEventListener("input", syncCompraCalculatedFields);
 			el.addEventListener("change", syncCompraCalculatedFields);
 		});
@@ -2072,12 +2117,14 @@
 			container.innerHTML = '<p class="text-sm text-muted-foreground festa-equipe-empty">Nenhum produto vinculado.</p>';
 			return;
 		}
+		var unidadeGeral = getSelectValue("compra-unidade") || "unidade";
+		var metaUnidade = unitOptionMeta(unidadeGeral);
 		var rows = compraDraftUsos.map(function (u, idx) {
 			return `
 <tr data-compra-uso-row>
 	<td>${renderNativeSelect("produto", produtosItems, u.produto || "", "compra-select-produto")}</td>
 	<td><input class="input festa-compact-input" data-field="quantidade_usada" type="text" inputmode="decimal" data-numeric-input value="${escHtml(u.quantidade_usada || "")}"></td>
-	<td>${renderNativeSelect("unidade_medida_uso", unidadesItems, u.unidade_medida_uso || "unidade")}</td>
+	<td>${renderBasecoatSelect("unidade_medida_uso", unidadesItems, u.unidade_medida_uso || "unidade", metaUnidade)}</td>
 	<td class="festa-table-actions"><button type="button" class="btn-sm-ghost festa-actions-btn" data-compra-remove-uso="${idx}" aria-label="Remover uso">×</button></td>
 </tr>`;
 		}).join("");
@@ -2096,7 +2143,9 @@
 </table>
 </div>`;
 		document.dispatchEvent(new CustomEvent("gris:design-system:init"));
-		container.querySelectorAll("input, select").forEach(function (el) {
+		// Inclui ".select" para capturar o evento change que o select Basecoat
+		// dispara no próprio componente (não no input hidden interno).
+		container.querySelectorAll("input, select, .select").forEach(function (el) {
 			el.addEventListener("input", syncCompraCalculatedFields);
 			el.addEventListener("change", syncCompraCalculatedFields);
 		});
@@ -2150,13 +2199,18 @@
 			}
 		}
 
+		// "Cotações a comprar" é uma contagem de cotações (sem unidade); "Total" e
+		// "Sobra individual" são quantidades na unidade de medida escolhida.
+		function fmtQtdUnidade(v, un) { return un ? (fmtNum(v) + " " + un) : fmtNum(v); }
 		var cenFields = [
 			{ min: "compra-cen-qtd-min", int: "compra-cen-qtd-int", max: "compra-cen-qtd-max",
 			  vMin: fmtNum(cen.min.qtd_sugerida), vInt: fmtNum(cen.intermediario.qtd_sugerida), vMax: fmtNum(cen.max.qtd_sugerida) },
+			{ min: "compra-cen-total-min", int: "compra-cen-total-int", max: "compra-cen-total-max",
+			  vMin: fmtQtdUnidade(cen.min.qtd_total_compra, cen.min.unidade_compra), vInt: fmtQtdUnidade(cen.intermediario.qtd_total_compra, cen.intermediario.unidade_compra), vMax: fmtQtdUnidade(cen.max.qtd_total_compra, cen.max.unidade_compra) },
 			{ min: "compra-cen-valor-min", int: "compra-cen-valor-int", max: "compra-cen-valor-max",
 			  vMin: fmtCurrency(cen.min.valor_total), vInt: fmtCurrency(cen.intermediario.valor_total), vMax: fmtCurrency(cen.max.valor_total) },
 			{ min: "compra-cen-sobra-qtd-min", int: "compra-cen-sobra-qtd-int", max: "compra-cen-sobra-qtd-max",
-			  vMin: fmtNum(cen.min.qtd_sobra_individual), vInt: fmtNum(cen.intermediario.qtd_sobra_individual), vMax: fmtNum(cen.max.qtd_sobra_individual) },
+			  vMin: fmtQtdUnidade(cen.min.qtd_sobra_individual, cen.min.unidade_compra), vInt: fmtQtdUnidade(cen.intermediario.qtd_sobra_individual, cen.intermediario.unidade_compra), vMax: fmtQtdUnidade(cen.max.qtd_sobra_individual, cen.max.unidade_compra) },
 			{ min: "compra-cen-sobra-valor-min", int: "compra-cen-sobra-valor-int", max: "compra-cen-sobra-valor-max",
 			  vMin: fmtCurrency(cen.min.valor_sobra), vInt: fmtCurrency(cen.intermediario.valor_sobra), vMax: fmtCurrency(cen.max.valor_sobra) },
 		];
@@ -2230,7 +2284,22 @@
 		var variaEl = document.querySelector("#compra-varia-publico input[type='checkbox']");
 		if (variaEl) variaEl.addEventListener("change", syncCompraCalculatedFields);
 		var unidadeEl = document.getElementById("compra-unidade");
-		if (unidadeEl) unidadeEl.addEventListener("change", syncCompraCalculatedFields);
+		if (unidadeEl) unidadeEl.addEventListener("change", function () {
+			// Ao trocar a unidade geral, reavaliamos as unidades de cotação e de
+			// uso: as que deixaram de ser conversíveis voltam para a unidade geral
+			// e os selects são redesenhados para refletir as opções ativas.
+			readCompraDrafts();
+			var gen = getSelectValue("compra-unidade") || "unidade";
+			compraDraftCotacoes.forEach(function (c) {
+				if (!unitsCompatible(c.unidade_medida || "unidade", gen)) c.unidade_medida = gen;
+			});
+			compraDraftUsos.forEach(function (u) {
+				if (!unitsCompatible(u.unidade_medida_uso || "unidade", gen)) u.unidade_medida_uso = gen;
+			});
+			renderCompraCotacoes();
+			renderCompraUsos();
+			syncCompraCalculatedFields();
+		});
 		var finalEl = document.getElementById("compra-quantidade-final");
 		if (finalEl) finalEl.addEventListener("input", function () {
 			finalEl.dataset.autoFinal = "0";

--- a/gris/www/festas/festa.py
+++ b/gris/www/festas/festa.py
@@ -161,6 +161,7 @@ def _hydrate_compra(doc, produto_labels: dict[str, str]) -> dict:
 		"valor_total_compra": flt(doc.valor_total_compra),
 		# Realizado
 		"valor_individual_realizado": flt(doc.valor_individual_realizado),
+		"quantidade_cotacao_realizada": flt(doc.quantidade_cotacao_realizada),
 		"unidade_medida_realizado": doc.unidade_medida_realizado or "unidade",
 		"quantidade_realizada": flt(doc.quantidade_realizada),
 		"valor_total_realizado": flt(doc.valor_total_realizado),


### PR DESCRIPTION
This pull request introduces a new PDF export feature for the "Lista de Compras" (Shopping List) in festas, enhances the UI and UX for managing purchases, and adds a new field to track the quantity actually purchased based on the selected quotation. The changes span backend, frontend, and template files, improving both data handling and user interaction.

**New Feature: PDF Export for Shopping List**
* Added a backend endpoint and supporting logic to generate a PDF shopping list for a festa, including a new Jinja template and WeasyPrint integration. The list includes only items with a selected quotation, is styled for print, and is accessible via a new button in the UI. [[1]](diffhunk://#diff-fd25075fb94c032404d4e6ae56f2f51af62a005888d9283e60d8663ffd7716d6R1-R150) [[2]](diffhunk://#diff-bfe3ae781c5bdb349591d7bd8ba5b6f7402884ac286aa3e13f6e650eabef5538R1-R140) [[3]](diffhunk://#diff-d9caf501933c07167765b7a2d57e9a9b2432f6af57bc728b0c6111b8061a00dbR355-R363) [[4]](diffhunk://#diff-d9caf501933c07167765b7a2d57e9a9b2432f6af57bc728b0c6111b8061a00dbR375)

**Data Model and API Enhancements**
* Added a new field `quantidade_cotacao_realizada` to `Compra Festa` (including schema, backend hydration, and update logic) to track the actual quantity purchased according to the selected quotation. [[1]](diffhunk://#diff-dfc05d408b90d85734b16785b41fc87be64f04408d9e746df58852ab3542d9f2R42) [[2]](diffhunk://#diff-dfc05d408b90d85734b16785b41fc87be64f04408d9e746df58852ab3542d9f2R250-R255) [[3]](diffhunk://#diff-42336687f97b7954926d794f3f1f743b4e027a6fdf8686c3984ce81310ac24d7R777) [[4]](diffhunk://#diff-42336687f97b7954926d794f3f1f743b4e027a6fdf8686c3984ce81310ac24d7R1035-R1037)

**UI/UX Improvements for Purchases**
* Updated the purchases section with a new header action group, improved scenario and summary tables, and restructured the realized purchase input area for clarity and better data entry, including tooltips and improved field labels. [[1]](diffhunk://#diff-d9caf501933c07167765b7a2d57e9a9b2432f6af57bc728b0c6111b8061a00dbL1562-R1577) [[2]](diffhunk://#diff-d9caf501933c07167765b7a2d57e9a9b2432f6af57bc728b0c6111b8061a00dbL1603-R1628) [[3]](diffhunk://#diff-d9caf501933c07167765b7a2d57e9a9b2432f6af57bc728b0c6111b8061a00dbL1758-L1783) [[4]](diffhunk://#diff-d9caf501933c07167765b7a2d57e9a9b2432f6af57bc728b0c6111b8061a00dbR355-R363) [[5]](diffhunk://#diff-d9caf501933c07167765b7a2d57e9a9b2432f6af57bc728b0c6111b8061a00dbR375)

**Design System and Accessibility**
* Enhanced select components to allow tooltips on disabled options, improved tooltip and info icon styling, and ensured better accessibility and clarity for unit selection and explanations. [[1]](diffhunk://#diff-bd09460a27b17834fb851ce56a05996dc3296af3d20319a7db3c6b902abcb70bR75-R80) [[2]](diffhunk://#diff-bd09460a27b17834fb851ce56a05996dc3296af3d20319a7db3c6b902abcb70bR502-R535) [[3]](diffhunk://#diff-0db0055c671695197d15e8b5cabe80677c2ec17e5b72e5b755a44ab44659ce21R367-R372) [[4]](diffhunk://#diff-d9caf501933c07167765b7a2d57e9a9b2432f6af57bc728b0c6111b8061a00dbL1562-R1577)

**Template and Integration Updates**
* Updated Jinja imports and template usage to support new tooltips and UI elements, ensuring consistency with the design system.

These changes collectively improve the festa purchase workflow, making it easier to prepare, track, and execute shopping for events, while providing a polished export option for use in the field.