### PR TITLE
Corrige carregamento duplicado de js e css das págins de fets

### DIFF
--- a/gris/www/festas/convite_confirmado.html
+++ b/gris/www/festas/convite_confirmado.html
@@ -4,10 +4,7 @@
 
 {% block title %}Pagamento confirmado{% endblock %}
 
-{% block head_include %}
-{{ super() }}
-<link rel="stylesheet" href="/festas/convite_confirmado.css" />
-{% endblock %}
+{# convite_confirmado.css/.js são injetados automaticamente pelo Frappe (colocated). Não referenciar manualmente: duplica o carregamento. #}
 
 {% block page_content %}
 <div class="cc-page" data-estado="{{ estado }}" data-convite="{{ convite_name }}" data-token="{{ convite_token }}">
@@ -56,7 +53,7 @@
 			<div class="cc-orientacoes">
 				{% if pagador_recebe_qr_codes %}
 				{% set descricao_html %}
-					Todos os convites foram enviados para <strong>{{ email_pagador_mascarado }}</strong>.
+					Todos os convites foram enviados para <strong>{{ email_pagador_mascarado }}</strong>
 					Apresente-os impressos ou no celular na entrada da festa.
 				{% endset %}
 				{{ alert(
@@ -141,5 +138,5 @@
 
 </div>
 
-<script src="/festas/convite_confirmado.js" defer></script>
+{# convite_confirmado.js é injetado automaticamente pelo Frappe (colocated). #}
 {% endblock %}

--- a/gris/www/festas/festa.html
+++ b/gris/www/festas/festa.html
@@ -17,7 +17,7 @@
 
 {% block head_include %}
 {{ super() }}
-<link rel="stylesheet" href="/festas/festa.css" />
+{# festa.css/.js são injetados automaticamente pelo Frappe (colocated) — não referenciar manualmente. Abaixo apenas assets de OUTROS arquivos (não co-localizados a esta página). #}
 <link rel="stylesheet" href="/festas/festa_avaliacoes.css" />
 <script src="/assets/gris/design_system/js/components/toastui-editor.js?v={{ design_system_asset_version }}" defer></script>
 <script src="/festas/festa_avaliacoes.js" defer></script>

--- a/gris/www/festas/nova_festa.html
+++ b/gris/www/festas/nova_festa.html
@@ -8,10 +8,7 @@
 
 {% set active_link = "/festas/nova_festa" %}
 
-{% block head_include %}
-{{ super() }}
-<link rel="stylesheet" href="/festas/nova_festa.css" />
-{% endblock %}
+{# nova_festa.css/.js são injetados automaticamente pelo Frappe (colocated). Não referenciar manualmente: duplica o carregamento. #}
 
 {% block page_header %}
 <section class="nova-festa-header" aria-labelledby="nova-festa-titulo">

--- a/gris/www/festas/portaria.html
+++ b/gris/www/festas/portaria.html
@@ -11,10 +11,7 @@
 
 {% set active_link = "/festas" %}
 
-{% block head_include %}
-{{ super() }}
-<link rel="stylesheet" href="/festas/portaria.css" />
-{% endblock %}
+{# portaria.css/.js são injetados automaticamente pelo Frappe (colocated). Não referenciar manualmente: duplica o carregamento. #}
 
 {% block page_header %}
 <div class="portaria-page-header">

--- a/gris/www/festas/relatorio.html
+++ b/gris/www/festas/relatorio.html
@@ -26,11 +26,7 @@
 
 {% set active_link = "/festas" %}
 
-{% block head_include %}
-{{ super() }}
-<link rel="stylesheet" href="/festas/relatorio.css" />
-<script src="/festas/relatorio.js" defer></script>
-{% endblock %}
+{# relatorio.css/.js são injetados automaticamente pelo Frappe (colocated). Não referenciar manualmente: duplica o carregamento (roda o script 2x). #}
 
 {% block page_header %}
 <div class="rel-header">

--- a/gris/www/festas/todas_festas.html
+++ b/gris/www/festas/todas_festas.html
@@ -6,10 +6,7 @@
 
 {% set active_link = "/festas/todas_festas" %}
 
-{% block head_include %}
-{{ super() }}
-<link rel="stylesheet" href="/festas/todas_festas.css" />
-{% endblock %}
+{# todas_festas.css/.js são injetados automaticamente pelo Frappe (colocated). Não referenciar manualmente: duplica o carregamento. #}
 
 {% block page_header %}
 <div class="page-header-row">

--- a/gris/www/festas/venda_convite.html
+++ b/gris/www/festas/venda_convite.html
@@ -8,10 +8,11 @@
 
 {% block title %}Comprar convites{% endblock %}
 
-{% block head_include %}
-{{ super() }}
-<link rel="stylesheet" href="/festas/venda_convite.css" />
-{% endblock %}
+{# O CSS e o JS co-localizados (venda_convite.css / venda_convite.js) são
+   injetados AUTOMATICAMENTE pelo Frappe (colocated_css/colocated_js em
+   frappe/templates/base.html). NÃO referenciar manualmente com <link>/<script>:
+   isso carrega o arquivo em DUPLICIDADE e faz o script rodar duas vezes, com
+   estados independentes disputando o mesmo botão/UI. #}
 
 {% block page_content %}
 <div class="vc-page">
@@ -287,5 +288,4 @@ window._vendaConvite = {
 
 </div>
 
-<script src="/festas/venda_convite.js"></script>
 {% endblock %}

--- a/gris/www/festas/venda_convite.js
+++ b/gris/www/festas/venda_convite.js
@@ -421,6 +421,9 @@
 		const telWrap = document.getElementById("vc-pagador-telefone");
 		if (telWrap) {
 			telWrap.addEventListener("phone-input:change", atualizarBotaoContinuarPedido);
+			// Revalida quando o phone-input termina de inicializar (a ordem de boot
+			// entre este script e o design system não é garantida).
+			telWrap.addEventListener("basecoat:initialized", atualizarBotaoContinuarPedido);
 			const hidden = telWrap.querySelector("[data-phone-input-value]");
 			if (hidden) hidden.addEventListener("change", atualizarBotaoContinuarPedido);
 			const numero = telWrap.querySelector("[data-phone-input-number]");
@@ -453,6 +456,10 @@
 				atualizarLinhasDoacao();
 			});
 		});
+
+		// Estado inicial: reflete valores já presentes (autofill/restauração) sem
+		// depender de um primeiro evento de input do usuário.
+		atualizarBotaoContinuarPedido();
 	}
 
 	// ─── Aba Convidados ─────────────────────────────────────────────────────


### PR DESCRIPTION
This pull request standardizes how CSS and JS assets are included in the `gris/www/festas` HTML templates by removing manual references to colocated assets, relying instead on Frappe's automatic asset injection. Additionally, it improves the initialization logic for the order button in `venda_convite.js` to ensure correct behavior even when the page is autofilled or when the design system loads asynchronously.

**Asset inclusion improvements:**

* Removed manual `<link>` and `<script>` tags for colocated CSS/JS files in all relevant HTML templates (`convite_confirmado.html`, `nova_festa.html`, `portaria.html`, `relatorio.html`, `todas_festas.html`, `venda_convite.html`), replacing them with comments explaining that Frappe injects these assets automatically, preventing duplicate loading and script execution. [[1]](diffhunk://#diff-c55311eaa0d145402acd6f6590be668edc8f261cf493d765cb9523afece28213L7-R7) [[2]](diffhunk://#diff-1ad747e5e7e653133bccb890e8003805e2d50bf6e3710483bf427f791f158f15L11-R11) [[3]](diffhunk://#diff-7521620e5c9865074025f825ed9469666b87ac5bb681fd3a7e30ec1cb2359022L14-R14) [[4]](diffhunk://#diff-a3f379c3dfdc1a12d6d9a167c7fc32196e797b741fb45273296cdc969caf5251L29-R29) [[5]](diffhunk://#diff-42b1458ee3a939c66343fa92fb8599fef57011d50596c6d24fcf8980687d4f68L9-R9) [[6]](diffhunk://#diff-b98b11b2d5cd08ec92c00e59ec243bb7ff974c66c50dd1c0414fca90129cdc16L11-R15) [[7]](diffhunk://#diff-b98b11b2d5cd08ec92c00e59ec243bb7ff974c66c50dd1c0414fca90129cdc16L290)

* Updated `festa.html` to clarify in comments that only non-colocated assets should be referenced manually, keeping colocated asset management consistent.

**Frontend logic enhancements:**

* In `venda_convite.js`, added an event listener for the `basecoat:initialized` event to handle cases where the phone input component initializes after the script, ensuring the "Continue Order" button is validated at the correct time.

* Ensured that the "Continue Order" button's state is correctly initialized on page load, reflecting any pre-filled or restored values without waiting for user input.

**Minor content fix:**

* Fixed a minor formatting issue in `convite_confirmado.html` by removing an unnecessary period from the invitation sent message.