### PR TITLE
feat(festas): exportar pedidos de convite em Excel

### DIFF
--- a/gris/api/festas/convites.py
+++ b/gris/api/festas/convites.py
@@ -343,6 +343,80 @@ def get_dashboard(festa_name: str) -> dict:
 	return build_dashboard(festa_name)
 
 
+@frappe.whitelist()
+def export_convites_excel(festa_name: str) -> None:
+	"""Exporta a tabela "Pedidos de convite" da festa em um arquivo Excel (.xlsx).
+
+	Gera uma linha por pedido (mesma visão da aba Convites), com todos os status.
+	"""
+	import io
+
+	from openpyxl import Workbook
+	from openpyxl.styles import Alignment, Font, PatternFill
+	from openpyxl.utils import get_column_letter
+
+	if not festa_name:
+		frappe.throw("Parâmetro 'festa_name' obrigatório.")
+	if not frappe.has_permission("Festa", "read", festa_name):
+		frappe.throw("Sem permissão para acessar esta festa.", frappe.PermissionError)
+	_validate_festa(festa_name)
+
+	dashboard = build_dashboard(festa_name)
+	linhas = dashboard.get("convites") or []
+
+	colunas = [
+		("Pagador", 32),
+		("E-mail", 32),
+		("Tipo de convite", 30),
+		("Qtd.", 8),
+		("Valor (R$)", 14),
+		("Status", 14),
+		("Data do pedido", 20),
+	]
+
+	wb = Workbook()
+	ws = wb.active
+	ws.title = "Pedidos de convite"
+
+	header_font = Font(bold=True, color="FFFFFF")
+	header_fill = PatternFill(start_color="0D4D91", end_color="0D4D91", fill_type="solid")
+	center = Alignment(horizontal="center", vertical="center")
+
+	for idx, (titulo, largura) in enumerate(colunas, start=1):
+		cell = ws.cell(row=1, column=idx, value=titulo)
+		cell.font = header_font
+		cell.fill = header_fill
+		cell.alignment = center
+		ws.column_dimensions[get_column_letter(idx)].width = largura
+
+	for ri, row in enumerate(linhas, start=2):
+		creation = row.get("creation") or ""
+		data_pedido = ""
+		if creation:
+			try:
+				data_pedido = frappe.utils.format_datetime(creation, "dd/MM/yyyy HH:mm")
+			except Exception:
+				data_pedido = creation
+		ws.cell(row=ri, column=1, value=row.get("nome_pagador") or "")
+		ws.cell(row=ri, column=2, value=row.get("email_pagador") or "")
+		ws.cell(row=ri, column=3, value=row.get("tipo_convite") or "")
+		ws.cell(row=ri, column=4, value=int(row.get("quantidade") or 0)).alignment = center
+		ws.cell(row=ri, column=5, value=flt(row.get("valor"))).number_format = "#,##0.00"
+		ws.cell(row=ri, column=6, value=row.get("status_pagamento") or "Pendente")
+		ws.cell(row=ri, column=7, value=data_pedido)
+
+	ws.freeze_panes = "A2"
+
+	out = io.BytesIO()
+	wb.save(out)
+	out.seek(0)
+
+	nome_festa = frappe.db.get_value("Festa", festa_name, "nome_festa") or festa_name
+	frappe.local.response.filename = f"pedidos-de-convite-{frappe.scrub(nome_festa)}.xlsx"
+	frappe.local.response.filecontent = out.read()
+	frappe.local.response.type = "download"
+
+
 # ---------------------------------------------------------------------------
 # Configurações da festa (switch + data limite)
 # ---------------------------------------------------------------------------

--- a/gris/www/festas/festa.html
+++ b/gris/www/festas/festa.html
@@ -624,6 +624,16 @@ window._festaData = {
 			<h2 class="festa-card__title">Pedidos de convite</h2>
 			<p class="festa-card__subtitle">Uma linha por item de convite (todos os status).</p>
 		</div>
+		<div class="festa-card__header-actions">
+			<button
+				type="button"
+				class="btn-sm-outline"
+				data-action="exportar-convites-xlsx"
+			>
+				{{ lucide_icon("file-spreadsheet", size="sm") }}
+				<span>Exportar Excel</span>
+			</button>
+		</div>
 	</div>
 	<div id="convites-table-container"></div>
 	{% endcall %}

--- a/gris/www/festas/festa.js
+++ b/gris/www/festas/festa.js
@@ -3683,6 +3683,16 @@
 			});
 		}
 
+		// Exportação da tabela de pedidos de convite em Excel (disponível para todos
+		// que enxergam a aba; é um download somente leitura).
+		document.querySelectorAll("[data-action='exportar-convites-xlsx']").forEach(function (btn) {
+			btn.addEventListener("click", function () {
+				const url = "/api/method/gris.api.festas.convites.export_convites_excel?festa_name="
+					+ encodeURIComponent(festaName);
+				window.open(url, "_blank");
+			});
+		});
+
 		if (!canEdit) return;
 
 		const dlg = document.getElementById("dialog-convites-config");


### PR DESCRIPTION
Adiciona botão "Exportar Excel" no card "Pedidos de convite" da aba
Convites (/festas/festa), que baixa um .xlsx com uma linha por pedido
(todos os status): pagador, e-mail, tipo de convite, quantidade, valor,
status de pagamento e data do pedido.

O endpoint reutiliza build_dashboard para manter os dados idênticos aos
exibidos na tabela e segue o padrão de download já usado no relatório
contábil e no relatório da festa (openpyxl + frappe.local.response).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011vXigaihEpc1FtmzzHVpJC