### PR TITLE
Adiciona função de envio de mensagem por whatsapp para participantes …

### DIFF
--- a/gris/api/festas/avaliacao.py
+++ b/gris/api/festas/avaliacao.py
@@ -73,6 +73,25 @@ def _get_festa(festa_name: str):
 	return frappe.get_doc("Festa", festa_name)
 
 
+def _pode_enviar_convidados(festa_doc) -> bool:
+	"""O envio de avaliação aos convidados só fica disponível a partir do dia seguinte à festa."""
+	if not festa_doc.data:
+		return False
+	return frappe.utils.getdate() > frappe.utils.getdate(festa_doc.data)
+
+
+def _whatsapp_integracao_ativa() -> bool:
+	"""True se a integração de WhatsApp está habilitada e configurada (não lança)."""
+	from gris.utils.whatsapp import _get_config
+	from gris.utils.whatsapp_errors import WhatsAppConfigurationError
+
+	try:
+		_get_config()
+		return True
+	except WhatsAppConfigurationError:
+		return False
+
+
 def _get_avaliacao_for_festa(festa_name: str):
 	name = frappe.db.get_value("Avaliacao Festa", {"festa": festa_name}, "name")
 	return frappe.get_doc("Avaliacao Festa", name) if name else None
@@ -133,6 +152,32 @@ def _collect_festa_team(festa_doc) -> list[dict[str, str]]:
 				add(membro.nome, membro.email, membro.telefone)
 
 	return team
+
+
+def _telefones_equipe_festa(festa_doc) -> set[str]:
+	"""Telefones (normalizados) de todos os envolvidos na organização da festa.
+
+	Coordenador geral, coordenadores e membros das equipes de área e de barraca — usado
+	para que a equipe não receba a mensagem de avaliação destinada aos convidados.
+	"""
+	from gris.utils.whatsapp import _normalize_phone
+
+	telefones: set[str] = set()
+
+	def add(telefone: str) -> None:
+		telefone = (telefone or "").strip()
+		if telefone:
+			telefones.add(_normalize_phone(telefone))
+
+	add(festa_doc.telefone_coord_geral)
+	for doctype in ("Area da Festa", "Barraca da Festa"):
+		for ref in frappe.get_all(doctype, filters={"festa": festa_doc.name}, fields=["name"]):
+			grupo = frappe.get_doc(doctype, ref.name)
+			add(grupo.telefone_coord)
+			for membro in grupo.equipe or []:
+				add(membro.telefone)
+
+	return telefones
 
 
 def _send_whatsapp(numero: str, mensagem: str, *, contexto: str) -> bool:
@@ -331,14 +376,81 @@ def gerar_pdf_qr_convidados(festa_name: str) -> None:
 
 
 @frappe.whitelist()
+def enviar_avaliacao_convidados_whatsapp(festa_name: str) -> dict[str, Any]:
+	"""Envia o link de avaliação de convidados por WhatsApp.
+
+	Alcança apenas convidados que compraram ingresso E entraram na festa (registro em
+	Lista Entrada Festa com status "Entrou") e que tenham telefone próprio preenchido.
+	Os telefones são deduplicados (um envio por número único). Disponível somente a
+	partir do dia seguinte à festa.
+	"""
+	from gris.festas.doctype.lista_entrada_festa.lista_entrada_festa import STATUS_ENTROU
+	from gris.utils.whatsapp import _get_config, _normalize_phone
+	from gris.utils.whatsapp_errors import WhatsAppConfigurationError
+
+	_ensure_gestor()
+	festa_doc = _get_festa(festa_name)
+	if not _pode_enviar_convidados(festa_doc):
+		frappe.throw(_("O envio só fica disponível a partir do dia seguinte à festa."))
+
+	# Falha cedo se a integração estiver desabilitada/mal configurada — assim o gestor
+	# recebe o motivo real em vez de um "envio iniciado" que nunca é entregue (o envio
+	# real roda em background e só valida a config dentro do worker).
+	try:
+		_get_config()
+	except WhatsAppConfigurationError as exc:
+		frappe.throw(str(exc))
+
+	avaliacao_doc = ensure_avaliacao_festa(festa_name)
+	link = _public_link(avaliacao_doc)
+
+	rows = frappe.get_all(
+		"Lista Entrada Festa",
+		filters={"festa": festa_name, "status": STATUS_ENTROU},
+		fields=["telefone"],
+	)
+
+	equipe_telefones = _telefones_equipe_festa(festa_doc)
+	vistos: set[str] = set()
+	telefones: list[str] = []
+	for r in rows:
+		bruto = (r.telefone or "").strip()
+		if not bruto:
+			continue
+		chave = _normalize_phone(bruto)
+		if chave in equipe_telefones or chave in vistos:
+			continue
+		vistos.add(chave)
+		telefones.append(bruto)
+
+	festa_titulo = festa_doc.nome_festa or festa_doc.name
+	mensagem = (
+		f"Olá! Ficamos muito felizes em ter recebido você na festa *{festa_titulo}*! 🎉\n\n"
+		"Gostaríamos muito de saber a sua opinião sobre como foi. "
+		"É bem rapidinho, é só acessar o link abaixo:\n"
+		f"{link}\n\n"
+		"Muito obrigado por contribuir para melhorarmos nossas festas!"
+	)
+
+	enviados = 0
+	for numero in telefones:
+		if _send_whatsapp(numero, mensagem, contexto=f"avaliacao_convidados:{festa_name}"):
+			enviados += 1
+
+	return {"ok": True, "enviados": enviados, "total_telefones": len(telefones)}
+
+
+@frappe.whitelist()
 def get_festa_avaliacao_data(festa_name: str) -> dict[str, Any]:
 	"""Retorna os dados da aba de avaliação (carregado sob demanda na abertura da aba).
 
 	A coleta de convidados (link público + QR) está disponível desde a criação da
 	festa; a avaliação da equipe só começa quando o gestor a inicia.
 	"""
-	_get_festa(festa_name)
+	festa_doc = _get_festa(festa_name)
 	can_edit = _can_edit()
+	can_send_convidados = can_edit and _pode_enviar_convidados(festa_doc)
+	whatsapp_integracao_ativa = can_edit and _whatsapp_integracao_ativa()
 	avaliacao_doc = _get_avaliacao_for_festa(festa_name)
 	if not avaliacao_doc and can_edit:
 		avaliacao_doc = ensure_avaliacao_festa(festa_name)
@@ -351,6 +463,8 @@ def get_festa_avaliacao_data(festa_name: str) -> dict[str, Any]:
 			"can_edit": False,
 			"can_start_evaluation": False,
 			"can_edit_general": False,
+			"can_send_convidados_whatsapp": False,
+			"whatsapp_integracao_ativa": False,
 			"public_link": "",
 			"public_link_qr": "",
 		}
@@ -363,6 +477,8 @@ def get_festa_avaliacao_data(festa_name: str) -> dict[str, Any]:
 		"can_edit": can_edit,
 		"can_start_evaluation": can_edit and not team_started,
 		"can_edit_general": can_edit and team_started,
+		"can_send_convidados_whatsapp": can_send_convidados,
+		"whatsapp_integracao_ativa": whatsapp_integracao_ativa,
 		"public_link": _public_link(avaliacao_doc),
 		"public_link_qr": _public_link_qr(avaliacao_doc),
 	}

--- a/gris/www/festas/festa.html
+++ b/gris/www/festas/festa.html
@@ -772,6 +772,7 @@ window._festaData = {
 			</div>
 			<div class="aval-qr-actions">
 				<button type="button" id="btnBaixarPdfQr" class="btn-sm-outline">{{ lucide_icon("printer", size="xs") }} Baixar PDF para impressão</button>
+				<button type="button" id="btnEnviarWhatsappConvidados" class="btn-sm-primary d-none" disabled>{{ lucide_icon("message-circle", size="xs") }} Enviar avaliação por WhatsApp</button>
 			</div>
 			<div class="aval-metrics mt-sm">
 				<div class="aval-metric-card">

--- a/gris/www/festas/festa_avaliacoes.css
+++ b/gris/www/festas/festa_avaliacoes.css
@@ -147,6 +147,9 @@
 
 .aval-qr-actions {
     display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
     justify-content: center;
     margin-top: 0.5rem;
 }

--- a/gris/www/festas/festa_avaliacoes.js
+++ b/gris/www/festas/festa_avaliacoes.js
@@ -10,6 +10,7 @@
         reenviar: "gris.api.festas.avaliacao.reenviar_email_avaliacao_festa",
         salvarGeral: "gris.api.festas.avaliacao.salvar_avaliacao_geral_festa",
         consultarResumo: "gris.api.festas.avaliacao.consultar_resumo_avaliacao_festa",
+        enviarConvidadosWhatsapp: "gris.api.festas.avaliacao.enviar_avaliacao_convidados_whatsapp",
     };
 
     var RESUMO_CONFIG = {
@@ -57,6 +58,51 @@
                 detail: { config: { category: category || "info", description: message, duration: 3500 } },
             })
         );
+    }
+
+    function confirmDialog(opts) {
+        opts = opts || {};
+        return new Promise(function (resolve) {
+            var dlg = $("confirm-dialog");
+            if (!dlg || typeof dlg.showModal !== "function") {
+                resolve(window.confirm(opts.message || opts.title || "Confirmar?"));
+                return;
+            }
+            var titleEl = dlg.querySelector("header h2");
+            var messageEl = dlg.querySelector("#confirm-dialog-message");
+            var okBtn = dlg.querySelector("#confirm-dialog-ok");
+            var cancelBtn = dlg.querySelector("#confirm-dialog-cancel");
+            if (titleEl) titleEl.textContent = opts.title || "Confirmar ação";
+            if (messageEl) messageEl.textContent = opts.message || "Tem certeza?";
+            if (okBtn) {
+                okBtn.textContent = opts.confirmLabel || "Confirmar";
+                okBtn.className = opts.variant === "primary" ? "btn-primary" : "btn-destructive";
+            }
+
+            function cleanup() {
+                if (okBtn) okBtn.removeEventListener("click", onOk);
+                if (cancelBtn) cancelBtn.removeEventListener("click", onCancel);
+                dlg.removeEventListener("close", onClose);
+            }
+            function onOk() {
+                cleanup();
+                dlg.close("confirm");
+                resolve(true);
+            }
+            function onCancel() {
+                cleanup();
+                dlg.close("cancel");
+                resolve(false);
+            }
+            function onClose() {
+                cleanup();
+                if (dlg.returnValue !== "confirm") resolve(false);
+            }
+            if (okBtn) okBtn.addEventListener("click", onOk);
+            if (cancelBtn) cancelBtn.addEventListener("click", onCancel);
+            dlg.addEventListener("close", onClose);
+            dlg.showModal();
+        });
     }
 
     function markdownToHtml(value) {
@@ -207,6 +253,12 @@
 
         var qr = $("avaliacaoPublicQr");
         if (qr) qr.src = data.public_link_qr || "";
+
+        var btnWa = $("btnEnviarWhatsappConvidados");
+        if (btnWa) {
+            show(btnWa, !!data.whatsapp_integracao_ativa);
+            btnWa.disabled = !data.can_send_convidados_whatsapp;
+        }
 
         if ($("avaliacaoMetricRecomendacao")) {
             $("avaliacaoMetricRecomendacao").textContent =
@@ -402,6 +454,34 @@
         window.open(url, "_blank");
     }
 
+    function enviarWhatsappConvidados() {
+        confirmDialog({
+            title: "Enviar avaliação por WhatsApp",
+            message: "Enviar a avaliação por WhatsApp para todos os convidados que entraram na festa?",
+            confirmLabel: "Enviar",
+            variant: "primary",
+        }).then(function (ok) {
+            if (!ok) return;
+            var btn = $("btnEnviarWhatsappConvidados");
+            if (btn) btn.disabled = true;
+            callApi(METHODS.enviarConvidadosWhatsapp, { festa_name: FESTA_NAME }).then(
+                function (r) {
+                    var enviados = r.enviados || 0;
+                    if (enviados > 0) {
+                        toast("Envio iniciado para " + enviados + " convidado(s).", "success");
+                    } else {
+                        toast("Nenhum convidado elegível para envio (com entrada, telefone e fora da equipe).", "info");
+                    }
+                    if (btn) btn.disabled = false;
+                },
+                function () {
+                    toast("Não foi possível enviar as mensagens.", "error");
+                    if (btn) btn.disabled = false;
+                }
+            );
+        });
+    }
+
     /* ── Binding ──────────────────────────────────────────────────────────── */
 
     function bind() {
@@ -423,6 +503,7 @@
             if (target.closest("#btnGerarResumoConvidados")) return gerarResumo("convidados");
             if (target.closest("#btnCopiarLinkConvidados")) return copiarLink();
             if (target.closest("#btnBaixarPdfQr")) return baixarPdfQr();
+            if (target.closest("#btnEnviarWhatsappConvidados")) return enviarWhatsappConvidados();
 
             var reenviar = target.closest("[data-reenviar-idx]");
             if (reenviar) return reenviarConvite(reenviar.getAttribute("data-reenviar-idx"));


### PR DESCRIPTION
This pull request adds the ability to send post-event evaluation links to party guests via WhatsApp, targeting only guests who attended the event and have a valid phone number. The feature is only available starting the day after the event, and ensures that organizers and team members do not receive the guest evaluation message. The UI and backend have been updated to support this workflow, including integration checks and user feedback.

**WhatsApp Evaluation Sending Feature:**

* Added the function `enviar_avaliacao_convidados_whatsapp` to send evaluation links by WhatsApp to guests who entered the event, deduplicating numbers and excluding team members; only available from the day after the event.
* Introduced helper functions `_pode_enviar_convidados`, `_whatsapp_integracao_ativa`, and `_telefones_equipe_festa` to control eligibility, integration status, and to filter out organizers' phone numbers. [[1]](diffhunk://#diff-349c126af223b7b172267507f245d8f56376efa47091d6cabfe92307b5e4e397R76-R94) [[2]](diffhunk://#diff-349c126af223b7b172267507f245d8f56376efa47091d6cabfe92307b5e4e397R157-R182)

**Frontend and User Experience:**

* Updated the evaluation tab UI to show a new WhatsApp send button (`btnEnviarWhatsappConvidados`) only if WhatsApp integration is active and the event is eligible; button is enabled/disabled based on backend checks. [[1]](diffhunk://#diff-d9caf501933c07167765b7a2d57e9a9b2432f6af57bc728b0c6111b8061a00dbR775) [[2]](diffhunk://#diff-f4eed1dd4f24e208e9d35ec58431eb7682b9c69af9e5f7bb21e6787932acb500R257-R262)
* Implemented a confirmation dialog before sending WhatsApp messages, and provided user feedback on the result of the operation. [[1]](diffhunk://#diff-f4eed1dd4f24e208e9d35ec58431eb7682b9c69af9e5f7bb21e6787932acb500R63-R107) [[2]](diffhunk://#diff-f4eed1dd4f24e208e9d35ec58431eb7682b9c69af9e5f7bb21e6787932acb500R457-R484) [[3]](diffhunk://#diff-f4eed1dd4f24e208e9d35ec58431eb7682b9c69af9e5f7bb21e6787932acb500R506)

**API and Data Exposure:**

* Modified the API response for the evaluation tab to include new fields: `can_send_convidados_whatsapp` and `whatsapp_integracao_ativa`, controlling button visibility and availability. [[1]](diffhunk://#diff-349c126af223b7b172267507f245d8f56376efa47091d6cabfe92307b5e4e397R466-R467) [[2]](diffhunk://#diff-349c126af223b7b172267507f245d8f56376efa47091d6cabfe92307b5e4e397R480-R481)

**Styling:**

* Improved the layout of the QR and WhatsApp action buttons for better usability.…da festa para fazer avaliação