### PR TITLE
Corrige problemas no fechamento da festa

### DIFF
--- a/gris/api/festas/__init__.py
+++ b/gris/api/festas/__init__.py
@@ -780,6 +780,7 @@ def _hydrate_compra(doc) -> dict:
 		"valor_total_realizado": flt(doc.valor_total_realizado),
 		"fornecedor_realizado": doc.fornecedor_realizado or "",
 		"observacoes_realizado": doc.observacoes_realizado or "",
+		"cancelado": bool(doc.cancelado),
 		"qtd_sugerida_min": flt(doc.qtd_sugerida_min),
 		"valor_total_min": flt(doc.valor_total_min),
 		"qtd_sobra_individual_min": flt(doc.qtd_sobra_individual_min),
@@ -950,6 +951,7 @@ def _hydrate_contratacao(doc) -> dict:
 		"valor_total_realizado": flt(doc.valor_total_realizado),
 		"fornecedor_realizado": doc.fornecedor_realizado or "",
 		"observacoes_realizado": doc.observacoes_realizado or "",
+		"cancelado": bool(doc.cancelado),
 		"cotacoes": [_hydrate_cotacao_contratacao(c) for c in (doc.cotacoes or [])],
 	}
 
@@ -1046,6 +1048,7 @@ def _apply_compra_realizado(doc, dados: dict) -> None:
 	)
 	doc.fornecedor_realizado = (dados.get("fornecedor_realizado") or "").strip()
 	doc.observacoes_realizado = (dados.get("observacoes_realizado") or "").strip()
+	doc.cancelado = _as_bool(dados.get("cancelado"))
 
 
 def _apply_contratacao_realizado(doc, dados: dict) -> None:
@@ -1054,6 +1057,7 @@ def _apply_contratacao_realizado(doc, dados: dict) -> None:
 	)
 	doc.fornecedor_realizado = (dados.get("fornecedor_realizado") or "").strip()
 	doc.observacoes_realizado = (dados.get("observacoes_realizado") or "").strip()
+	doc.cancelado = _as_bool(dados.get("cancelado"))
 
 
 def _apply_compra_usos_sem_previsao(doc, dados: dict, festa_name: str) -> None:
@@ -1119,6 +1123,32 @@ def criar_compra_sem_previsao(festa_name: str, dados_json: str) -> dict:
 
 
 @frappe.whitelist()
+def salvar_compra_sem_previsao(compra_name: str, dados_json: str) -> dict:
+	_ensure_gestor()
+	dados = _parse_json_dict(dados_json)
+
+	doc = frappe.get_doc("Compra Festa", compra_name)
+	if doc.previsto:
+		frappe.throw("Apenas itens sem previsão podem ser editados aqui.")
+
+	nome_item = (dados.get("nome_item") or "").strip()
+	if not nome_item:
+		frappe.throw("Informe o nome do item.")
+
+	doc.nome_item = nome_item
+	doc.area = _validate_area_festa(dados.get("area"), doc.festa)
+	doc.usado_em_produtos = _as_bool(dados.get("usado_em_produtos"))
+	doc.unidade_compra = _validate_unidade(
+		dados.get("unidade_medida_realizado") or "unidade"
+	)
+	_apply_compra_usos_sem_previsao(doc, dados, doc.festa)
+	_apply_compra_realizado(doc, dados)
+	doc.save()
+	doc.reload()
+	return {"ok": True, "compra": _hydrate_compra(doc)}
+
+
+@frappe.whitelist()
 def salvar_realizado_contratacao(contratacao_name: str, dados_json: str) -> dict:
 	_ensure_gestor()
 	dados = _parse_json_dict(dados_json)
@@ -1147,6 +1177,27 @@ def criar_contratacao_sem_previsao(festa_name: str, dados_json: str) -> dict:
 	doc.area = _validate_area_festa(dados.get("area"), festa_name)
 	_apply_contratacao_realizado(doc, dados)
 	doc.insert()
+	doc.reload()
+	return {"ok": True, "contratacao": _hydrate_contratacao(doc)}
+
+
+@frappe.whitelist()
+def salvar_contratacao_sem_previsao(contratacao_name: str, dados_json: str) -> dict:
+	_ensure_gestor()
+	dados = _parse_json_dict(dados_json)
+
+	doc = frappe.get_doc("Contratacao Festa", contratacao_name)
+	if doc.previsto:
+		frappe.throw("Apenas itens sem previsão podem ser editados aqui.")
+
+	nome_item = (dados.get("nome_item") or "").strip()
+	if not nome_item:
+		frappe.throw("Informe o nome do item.")
+
+	doc.nome_item = nome_item
+	doc.area = _validate_area_festa(dados.get("area"), doc.festa)
+	_apply_contratacao_realizado(doc, dados)
+	doc.save()
 	doc.reload()
 	return {"ok": True, "contratacao": _hydrate_contratacao(doc)}
 

--- a/gris/api/festas/relatorio.py
+++ b/gris/api/festas/relatorio.py
@@ -386,6 +386,7 @@ def build_relatorio_payload(festa_name: str) -> dict:
 			"valor_total_realizado",
 			"fornecedor_realizado",
 			"observacoes_realizado",
+			"cancelado",
 		],
 		order_by="nome_item asc",
 	)
@@ -400,6 +401,7 @@ def build_relatorio_payload(festa_name: str) -> dict:
 			"valor_total_realizado",
 			"fornecedor_realizado",
 			"observacoes_realizado",
+			"cancelado",
 		],
 		order_by="nome_item asc",
 	)
@@ -422,6 +424,7 @@ def build_relatorio_payload(festa_name: str) -> dict:
 			"valor_total_realizado": flt(c.valor_total_realizado),
 			"fornecedor_realizado": c.fornecedor_realizado or "",
 			"observacoes": c.observacoes_realizado or "",
+			"cancelado": bool(c.cancelado),
 		}
 		for c in compras
 	]
@@ -433,15 +436,21 @@ def build_relatorio_payload(festa_name: str) -> dict:
 			"valor_realizado": flt(c.valor_total_realizado),
 			"fornecedor_realizado": c.fornecedor_realizado or "",
 			"observacoes": c.observacoes_realizado or "",
+			"cancelado": bool(c.cancelado),
 		}
 		for c in contratacoes
 	]
 
 	# Despesa realizada por área (compras + contratações).
+	# Itens cancelados (não comprados) não entram nas despesas.
 	despesa_area: dict[str, float] = {}
 	for c in compras:
+		if c.cancelado:
+			continue
 		despesa_area[c.area or ""] = despesa_area.get(c.area or "", 0.0) + flt(c.valor_total_realizado)
 	for c in contratacoes:
+		if c.cancelado:
+			continue
 		despesa_area[c.area or ""] = despesa_area.get(c.area or "", 0.0) + flt(c.valor_total_realizado)
 	despesas_por_area = [
 		{"label": area_nome.get(a, "Sem área") if a else "Sem área", "valor": v}

--- a/gris/festas/doctype/compra_festa/compra_festa.json
+++ b/gris/festas/doctype/compra_festa/compra_festa.json
@@ -44,7 +44,8 @@
   "quantidade_realizada",
   "valor_total_realizado",
   "fornecedor_realizado",
-  "observacoes_realizado"
+  "observacoes_realizado",
+  "cancelado"
  ],
  "fields": [
   {
@@ -280,6 +281,12 @@
    "fieldname": "observacoes_realizado",
    "fieldtype": "Small Text",
    "label": "Observações"
+  },
+  {
+   "default": "0",
+   "fieldname": "cancelado",
+   "fieldtype": "Check",
+   "label": "Cancelado (não comprado)"
   }
  ],
  "grid_page_length": 50,

--- a/gris/festas/doctype/compra_festa/test_compra_festa.py
+++ b/gris/festas/doctype/compra_festa/test_compra_festa.py
@@ -1,6 +1,17 @@
+import json
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days, flt, today
+
+from gris.api.festas import (
+	criar_compra,
+	criar_compra_sem_previsao,
+	excluir_compra,
+	salvar_compra_sem_previsao,
+	salvar_realizado_compra,
+)
+from gris.api.festas.relatorio import build_relatorio_payload
 
 
 def _nova_festa():
@@ -109,6 +120,66 @@ class TestCompraFesta(FrappeTestCase):
 		)
 
 		self.assertRaises(frappe.ValidationError, compra.insert, ignore_permissions=True)
+
+	def test_compra_sem_previsao_pode_ser_criada_editada_e_removida(self):
+		festa = _nova_festa()
+		r = criar_compra_sem_previsao(
+			festa.name, json.dumps({"nome_item": "Gelo", "valor_total_realizado": 50, "cancelado": 1})
+		)
+		compra = r["compra"]
+		self.assertFalse(compra["previsto"])
+		self.assertTrue(compra["cancelado"])
+		self.assertEqual(flt(compra["valor_total_realizado"]), 50)
+
+		# Editar nome e desmarcar cancelado (item passou a ser comprado).
+		r2 = salvar_compra_sem_previsao(
+			compra["name"],
+			json.dumps({"nome_item": "Gelo em cubos", "valor_total_realizado": 50, "cancelado": 0}),
+		)
+		self.assertEqual(r2["compra"]["nome_item"], "Gelo em cubos")
+		self.assertFalse(r2["compra"]["cancelado"])
+
+		excluir_compra(compra["name"], festa.name)
+		self.assertFalse(frappe.db.exists("Compra Festa", compra["name"]))
+
+	def test_salvar_compra_sem_previsao_recusa_item_previsto(self):
+		festa = _nova_festa()
+		compra = criar_compra(
+			festa.name,
+			json.dumps(
+				{
+					"nome_item": "Carvao",
+					"unidade_medida_realizado": "kg",
+					"quantidade_compra_final": 5,
+					"cotacoes": [
+						{"fornecedor": "A", "valor": 10, "quantidade": 1, "unidade_medida": "kg", "escolhida": 1}
+					],
+				}
+			),
+		)["compra"]
+		self.assertRaises(
+			frappe.ValidationError,
+			salvar_compra_sem_previsao,
+			compra["name"],
+			json.dumps({"nome_item": "Outro", "valor_total_realizado": 10}),
+		)
+
+	def test_item_cancelado_nao_entra_nas_despesas_do_relatorio(self):
+		festa = _nova_festa()
+		# Item comprado (entra nas despesas).
+		criar_compra_sem_previsao(
+			festa.name, json.dumps({"nome_item": "Comprado", "valor_total_realizado": 50, "cancelado": 0})
+		)
+		# Item cancelado com valor gasto (NÃO deve contar).
+		criar_compra_sem_previsao(
+			festa.name, json.dumps({"nome_item": "Cancelado", "valor_total_realizado": 200, "cancelado": 1})
+		)
+
+		payload = build_relatorio_payload(festa.name)
+		self.assertEqual(flt(payload["despesas"]), 50)
+		flags = {c["nome_item"]: c["cancelado"] for c in payload["compras"]}
+		self.assertTrue(flags["Cancelado"])
+		self.assertFalse(flags["Comprado"])
 
 	def test_unidade_incompativel_falha_no_calculo(self):
 		festa = _nova_festa()

--- a/gris/festas/doctype/contratacao_festa/contratacao_festa.json
+++ b/gris/festas/doctype/contratacao_festa/contratacao_festa.json
@@ -17,7 +17,8 @@
   "realizado_section",
   "valor_total_realizado",
   "fornecedor_realizado",
-  "observacoes_realizado"
+  "observacoes_realizado",
+  "cancelado"
  ],
  "fields": [
   {
@@ -89,6 +90,12 @@
    "fieldname": "observacoes_realizado",
    "fieldtype": "Small Text",
    "label": "Observações"
+  },
+  {
+   "default": "0",
+   "fieldname": "cancelado",
+   "fieldtype": "Check",
+   "label": "Cancelado (não comprado)"
   }
  ],
  "grid_page_length": 50,

--- a/gris/festas/doctype/contratacao_festa/test_contratacao_festa.py
+++ b/gris/festas/doctype/contratacao_festa/test_contratacao_festa.py
@@ -1,0 +1,86 @@
+import json
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import flt, today
+
+from gris.api.festas import (
+	criar_contratacao,
+	criar_contratacao_sem_previsao,
+	excluir_contratacao,
+	salvar_contratacao_sem_previsao,
+	salvar_realizado_contratacao,
+)
+
+
+def _nova_festa():
+	festa = frappe.get_doc(
+		{
+			"doctype": "Festa",
+			"nome_festa": f"Festa Teste {frappe.generate_hash(length=8)}",
+			"data": today(),
+			"data_limite_vendas": today(),
+			"status": "Em andamento",
+		}
+	).insert(ignore_permissions=True)
+	portaria = frappe.get_doc("Area da Festa", f"{festa.name} - Portaria")
+	portaria.nome_coord = "Coord Portaria"
+	portaria.email_coord = "portaria@example.com"
+	portaria.telefone_coord = "+5511999999999"
+	portaria.save(ignore_permissions=True)
+	return festa
+
+
+class TestContratacaoFesta(FrappeTestCase):
+	def test_sem_previsao_pode_ser_criada_editada_e_removida(self):
+		festa = _nova_festa()
+		r = criar_contratacao_sem_previsao(
+			festa.name, json.dumps({"nome_item": "Som", "valor_total_realizado": 300, "cancelado": 1})
+		)
+		contr = r["contratacao"]
+		self.assertFalse(contr["previsto"])
+		self.assertTrue(contr["cancelado"])
+
+		r2 = salvar_contratacao_sem_previsao(
+			contr["name"],
+			json.dumps({"nome_item": "Som e luz", "valor_total_realizado": 300, "cancelado": 0}),
+		)
+		self.assertEqual(r2["contratacao"]["nome_item"], "Som e luz")
+		self.assertFalse(r2["contratacao"]["cancelado"])
+
+		excluir_contratacao(contr["name"], festa.name)
+		self.assertFalse(frappe.db.exists("Contratacao Festa", contr["name"]))
+
+	def test_salvar_sem_previsao_recusa_item_previsto(self):
+		festa = _nova_festa()
+		contr = criar_contratacao(
+			festa.name,
+			json.dumps(
+				{
+					"nome_item": "Segurança",
+					"cotacoes": [{"fornecedor": "A", "valor": 500, "escolhida": 1}],
+				}
+			),
+		)["contratacao"]
+		self.assertRaises(
+			frappe.ValidationError,
+			salvar_contratacao_sem_previsao,
+			contr["name"],
+			json.dumps({"nome_item": "Outro", "valor_total_realizado": 10}),
+		)
+
+	def test_realizado_grava_cancelado(self):
+		festa = _nova_festa()
+		contr = criar_contratacao(
+			festa.name,
+			json.dumps(
+				{
+					"nome_item": "Banheiros",
+					"cotacoes": [{"fornecedor": "A", "valor": 400, "escolhida": 1}],
+				}
+			),
+		)["contratacao"]
+		salvar_realizado_contratacao(
+			contr["name"], json.dumps({"valor_total_realizado": 400, "cancelado": 1})
+		)
+		self.assertEqual(frappe.db.get_value("Contratacao Festa", contr["name"], "cancelado"), 1)

--- a/gris/templates/pages/relatorio_festa_pdf_corpo.html
+++ b/gris/templates/pages/relatorio_festa_pdf_corpo.html
@@ -108,7 +108,7 @@
 	<tbody>
 		{% for c in linhas %}
 		<tr>
-			<td>{{ c.nome_item }}</td>
+			<td>{{ c.nome_item }}{% if c.cancelado %} <span class="badge badge--cancelado">Cancelado</span>{% endif %}</td>
 			<td class="num">{{ brl(c.valor_individual_orcado) }}</td>
 			<td class="num">{{ qty(c.qtd_orcada) }}</td>
 			<td class="num">{{ brl(c.valor_total_orcado) }}</td>
@@ -134,7 +134,7 @@
 	<tbody>
 		{% for c in linhas %}
 		<tr>
-			<td>{{ c.nome_item }}</td>
+			<td>{{ c.nome_item }}{% if c.cancelado %} <span class="badge badge--cancelado">Cancelado</span>{% endif %}</td>
 			<td class="num">{{ brl(c.valor_orcado) }}</td>
 			<td>{{ c.fornecedor_orcado }}</td>
 			<td class="num">{{ brl(c.valor_realizado) }}</td>
@@ -292,6 +292,8 @@
 			border-radius: 999px; padding: 1mm 3mm; font-size: 8.5pt; font-weight: 600; margin: 0 1.5mm 1.5mm 0; }
 		.badge { display: inline-block; background: linear-gradient(140deg, #4F39F6, #1231E4);
 			color: #fff; border-radius: 6px; padding: 1mm 3mm; font-size: 9pt; font-weight: 700; }
+		/* Item cancelado (não comprado): cor sólida (WeasyPrint 59 é instável com var() em gradiente). */
+		.badge--cancelado { background: #dc2626; font-size: 7pt; padding: 0.3mm 2mm; }
 		/* Mini-cards empilhados: um abaixo do outro, largura total (sem dividir
 		   colunas). Bloco em vez de flex — o flex do WeasyPrint 59 é instável. */
 		.cards--stack { display: block; }

--- a/gris/www/festas/festa.css
+++ b/gris/www/festas/festa.css
@@ -875,6 +875,17 @@
 	border-bottom: 1px solid var(--border);
 }
 
+/* Badge de item de compra/contratação cancelado (não comprado) */
+.festa-badge-cancelado {
+	background-color: var(--destructive);
+	color: var(--destructive-foreground);
+}
+
+/* Botão "Remover item" no rodapé dos diálogos de fechamento: alinhado à esquerda */
+.festa-fechamento-remover {
+	margin-right: auto;
+}
+
 /* Lista de itens vinculados no dialog informativo de exclusão bloqueada */
 .festa-info-dialog-list {
 	margin: 0.75rem 0 0;

--- a/gris/www/festas/festa.html
+++ b/gris/www/festas/festa.html
@@ -1818,6 +1818,9 @@ window._festaData = {
 		{# Realizado — inputs #}
 		<div class="festa-compra-section" data-fechamento-block="realizado">
 			<h3 class="festa-equipe-title">Realizado</h3>
+			{% call field(label="Item comprado") %}
+				{{ switch(name="fechamento-compra-comprado", checked=true, attrs={"id": "fechamento-compra-comprado"}) }}
+			{% endcall %}
 			<div class="festa-table-scroll">
 				<table class="festa-table festa-edit-table">
 					<thead>
@@ -1854,6 +1857,7 @@ window._festaData = {
 		</div>
 	</section>
 	<footer>
+		<button type="button" class="btn-destructive festa-fechamento-remover" id="btn-fechamento-compra-remover" hidden>Remover item</button>
 		<button type="button" class="btn-outline" onclick="this.closest('dialog').close()">Cancelar</button>
 		<button type="button" class="btn-primary" id="btn-fechamento-compra-salvar">Salvar</button>
 	</footer>
@@ -1899,6 +1903,9 @@ window._festaData = {
 		{# Realizado — inputs #}
 		<div class="festa-compra-section" data-fechamento-block="realizado">
 			<h3 class="festa-equipe-title">Realizado</h3>
+			{% call field(label="Item comprado") %}
+				{{ switch(name="fechamento-contratacao-comprado", checked=true, attrs={"id": "fechamento-contratacao-comprado"}) }}
+			{% endcall %}
 			<div class="festa-dialog-form festa-compra-form-grid">
 				{% call field(label="Valor total") %}
 					{{ currency_input(id="fechamento-contratacao-real-total") }}
@@ -1913,6 +1920,7 @@ window._festaData = {
 		</div>
 	</section>
 	<footer>
+		<button type="button" class="btn-destructive festa-fechamento-remover" id="btn-fechamento-contratacao-remover" hidden>Remover item</button>
 		<button type="button" class="btn-outline" onclick="this.closest('dialog').close()">Cancelar</button>
 		<button type="button" class="btn-primary" id="btn-fechamento-contratacao-salvar">Salvar</button>
 	</footer>

--- a/gris/www/festas/festa.js
+++ b/gris/www/festas/festa.js
@@ -3904,6 +3904,7 @@
 		var key = fechamentoCenarioKey();
 		var rows = compras.map(function (c, i) {
 			var tag = c.previsto === false ? ' <span class="badge">Sem previsão</span>' : "";
+			var cancelBadge = c.cancelado ? ' <span class="badge festa-badge-cancelado">Cancelado</span>' : "";
 			var detalhes = canEdit
 				? `<td class="festa-table-actions"><button type="button" class="btn-sm-outline" data-fechamento-compra="${i}">Detalhes</button></td>`
 				: "";
@@ -3925,7 +3926,7 @@
 			var totalPrevisto = qtd * qtdPacote;
 			return `
 <tr>
-	<td>${escHtml(c.nome_item)}${tag}</td>
+	<td>${escHtml(c.nome_item)}${tag}${cancelBadge}</td>
 	<td>${fmtNum(c.quantidade_compra_final)}</td>
 	<td>${fmtNum(totalPrevisto)} ${escHtml(c.unidade_compra || "")}</td>
 	<td>${fmtCurrency(valorCotado)}</td>
@@ -3955,6 +3956,7 @@
 		// realizado já preenchido, preservamos o valor digitado pelo gestor.
 		totalEl.dataset.autoTotal = Number(c.valor_total_realizado) > 0 ? "0" : "1";
 		document.getElementById("fechamento-compra-real-obs").value = c.observacoes_realizado || "";
+		setSwitchChecked("fechamento-compra-comprado", !c.cancelado);
 		syncFechamentoRealizado();
 	}
 
@@ -3985,10 +3987,13 @@
 		var blocoIdent = dlg.querySelector('[data-fechamento-block="identificacao"]');
 		var blocoOrc = dlg.querySelector('[data-fechamento-block="orcamento"]');
 
+		var btnRemover = document.getElementById("btn-fechamento-compra-remover");
+
 		if (idx < 0) {
 			titleEl.textContent = "Adicionar compra sem previsão";
 			blocoIdent.hidden = false;
 			blocoOrc.hidden = true;
+			if (btnRemover) btnRemover.hidden = true;
 			document.getElementById("fechamento-compra-nome-item").value = "";
 			setSelectValue("fechamento-compra-area", "", selectLabelFor(areasItems, "", "Sem área"));
 			setSwitchChecked("fechamento-compra-usado-produtos", false);
@@ -3998,11 +4003,28 @@
 			setRealizadoCompra({});
 		} else {
 			var compra = compras[idx];
+			var semPrevisao = compra.previsto === false;
 			titleEl.textContent = "Detalhes da compra — " + (compra.nome_item || "");
-			blocoIdent.hidden = true;
-			if (compra.previsto !== false) {
+			// Itens sem previsão podem ser removidos e ter nome/área/usos editados.
+			if (btnRemover) btnRemover.hidden = !semPrevisao;
+			if (semPrevisao) {
+				blocoIdent.hidden = false;
+				blocoOrc.hidden = true;
+				document.getElementById("fechamento-compra-nome-item").value = compra.nome_item || "";
+				setSelectValue("fechamento-compra-area", compra.area || "", compra.nome_area || selectLabelFor(areasItems, "", "Sem área"));
+				setSwitchChecked("fechamento-compra-usado-produtos", !!compra.usado_em_produtos);
+				fechamentoCompraUsos = (compra.usos_em_produto || []).map(function (u) {
+					return {
+						produto: u.produto || "",
+						quantidade_usada: u.quantidade_usada || 0,
+						unidade_medida_uso: u.unidade_medida_uso || "unidade",
+					};
+				});
+				renderFechamentoCompraUsos();
+				updateFechamentoCompraUsosVisibility();
+			} else {
+				blocoIdent.hidden = true;
 				blocoOrc.hidden = false;
-				var key = fechamentoCenarioKey();
 				var escolhida = (compra.cotacoes || []).find(function (x) { return x.escolhida; });
 				var valIndividual = escolhida && Number(escolhida.quantidade) > 0 && !escolhida.doacao
 					? (Number(escolhida.valor) || 0) / Number(escolhida.quantidade) : 0;
@@ -4024,10 +4046,8 @@
 				}
 				fechamentoSetText("fechamento-compra-orc-totalqtd",
 					fmtNum(qtdCompraFinal * qtdPacoteOrc) + " " + (compra.unidade_compra || ""));
-				fechamentoSetText("fechamento-compra-orc-total", fmtCurrency(compra["valor_total_" + key]));
+				fechamentoSetText("fechamento-compra-orc-total", fmtCurrency(compra.valor_total_compra));
 				fechamentoSetText("fechamento-compra-orc-fornecedor", escolhida ? (escolhida.fornecedor || "—") : "—");
-			} else {
-				blocoOrc.hidden = true;
 			}
 			setRealizadoCompra(compra);
 		}
@@ -4086,6 +4106,7 @@
 			valor_total_realizado: parseFloat(document.getElementById("fechamento-compra-real-total").value) || 0,
 			fornecedor_realizado: (document.getElementById("fechamento-compra-real-fornecedor").value || "").trim(),
 			observacoes_realizado: (document.getElementById("fechamento-compra-real-obs").value || "").trim(),
+			cancelado: getSwitchChecked("fechamento-compra-comprado") ? 0 : 1,
 		};
 	}
 
@@ -4094,7 +4115,8 @@
 		var idx = parseInt(dlg.dataset.compraIdx, 10);
 		var dados = collectCompraRealizado();
 		var request;
-		if (idx < 0) {
+		if (idx < 0 || compras[idx].previsto === false) {
+			// Criação (idx<0) ou edição de item sem previsão: nome/área/usos editáveis.
 			var nome = (document.getElementById("fechamento-compra-nome-item").value || "").trim();
 			if (!nome) { toast("Informe o nome do item.", "error"); return; }
 			readFechamentoCompraUsos();
@@ -4102,7 +4124,9 @@
 			dados.area = getSelectValue("fechamento-compra-area");
 			dados.usado_em_produtos = getSwitchChecked("fechamento-compra-usado-produtos");
 			dados.usos_em_produto = dados.usado_em_produtos ? fechamentoCompraUsos : [];
-			request = api("gris.api.festas.criar_compra_sem_previsao", { festa_name: festaName, dados_json: JSON.stringify(dados) });
+			request = idx < 0
+				? api("gris.api.festas.criar_compra_sem_previsao", { festa_name: festaName, dados_json: JSON.stringify(dados) })
+				: api("gris.api.festas.salvar_compra_sem_previsao", { compra_name: compras[idx].name, dados_json: JSON.stringify(dados) });
 		} else {
 			request = api("gris.api.festas.salvar_realizado_compra", { compra_name: compras[idx].name, dados_json: JSON.stringify(dados) });
 		}
@@ -4115,6 +4139,24 @@
 			.finally(function () { btn.disabled = false; });
 	}
 
+	function removerCompraFechamento() {
+		var dlg = document.getElementById("dialog-compra-fechamento");
+		var idx = parseInt(dlg.dataset.compraIdx, 10);
+		if (!(idx >= 0)) return;
+		var compra = compras[idx];
+		confirmDialog({
+			title: "Remover item",
+			message: "Remover a compra \"" + compra.nome_item + "\"? Esta ação não pode ser desfeita.",
+			confirmLabel: "Remover",
+		}).then(function (ok) {
+			if (!ok) return;
+			api("gris.api.festas.excluir_compra", { compra_name: compra.name, festa_name: festaName })
+				.then(function () { dlg.close(); return refreshFestaData(); })
+				.then(function () { toast("Item removido.", "success"); })
+				.catch(function (err) { toast(err.message || "Erro ao remover item.", "error"); });
+		});
+	}
+
 	// ── Contratações ──
 
 	function renderFechamentoContratacoes() {
@@ -4124,12 +4166,13 @@
 
 		var rows = contratacoes.map(function (c, i) {
 			var tag = c.previsto === false ? ' <span class="badge">Sem previsão</span>' : "";
+			var cancelBadge = c.cancelado ? ' <span class="badge festa-badge-cancelado">Cancelado</span>' : "";
 			var detalhes = canEdit
 				? `<td class="festa-table-actions"><button type="button" class="btn-sm-outline" data-fechamento-contratacao="${i}">Detalhes</button></td>`
 				: "";
 			return `
 <tr>
-	<td>${escHtml(c.nome_item)}${tag}</td>
+	<td>${escHtml(c.nome_item)}${tag}${cancelBadge}</td>
 	<td>${fmtCurrency(c.valor_total_contratacao)}</td>
 	<td>${fmtCurrency(c.valor_total_realizado)}</td>
 	${detalhes}
@@ -4149,6 +4192,7 @@
 		document.getElementById("fechamento-contratacao-real-total").value = c.valor_total_realizado || "";
 		document.getElementById("fechamento-contratacao-real-fornecedor").value = c.fornecedor_realizado || "";
 		document.getElementById("fechamento-contratacao-real-obs").value = c.observacoes_realizado || "";
+		setSwitchChecked("fechamento-contratacao-comprado", !c.cancelado);
 	}
 
 	function openContratacaoFechamentoDialog(idx) {
@@ -4159,24 +4203,32 @@
 		var blocoIdent = dlg.querySelector('[data-fechamento-block="identificacao"]');
 		var blocoOrc = dlg.querySelector('[data-fechamento-block="orcamento"]');
 
+		var btnRemover = document.getElementById("btn-fechamento-contratacao-remover");
+
 		if (idx < 0) {
 			titleEl.textContent = "Adicionar contratação sem previsão";
 			blocoIdent.hidden = false;
 			blocoOrc.hidden = true;
+			if (btnRemover) btnRemover.hidden = true;
 			document.getElementById("fechamento-contratacao-nome-item").value = "";
 			setSelectValue("fechamento-contratacao-area", "", selectLabelFor(areasItems, "", "Sem área"));
 			setRealizadoContratacao({});
 		} else {
 			var c = contratacoes[idx];
+			var semPrevisao = c.previsto === false;
 			titleEl.textContent = "Detalhes da contratação — " + (c.nome_item || "");
-			blocoIdent.hidden = true;
-			if (c.previsto !== false) {
+			if (btnRemover) btnRemover.hidden = !semPrevisao;
+			if (semPrevisao) {
+				blocoIdent.hidden = false;
+				blocoOrc.hidden = true;
+				document.getElementById("fechamento-contratacao-nome-item").value = c.nome_item || "";
+				setSelectValue("fechamento-contratacao-area", c.area || "", c.nome_area || selectLabelFor(areasItems, "", "Sem área"));
+			} else {
+				blocoIdent.hidden = true;
 				blocoOrc.hidden = false;
 				var escolhida = (c.cotacoes || []).find(function (x) { return x.escolhida; });
 				fechamentoSetText("fechamento-contratacao-orc-total", fmtCurrency(c.valor_total_contratacao));
 				fechamentoSetText("fechamento-contratacao-orc-fornecedor", escolhida ? (escolhida.fornecedor || "—") : "—");
-			} else {
-				blocoOrc.hidden = true;
 			}
 			setRealizadoContratacao(c);
 		}
@@ -4190,14 +4242,18 @@
 			valor_total_realizado: parseFloat(document.getElementById("fechamento-contratacao-real-total").value) || 0,
 			fornecedor_realizado: (document.getElementById("fechamento-contratacao-real-fornecedor").value || "").trim(),
 			observacoes_realizado: (document.getElementById("fechamento-contratacao-real-obs").value || "").trim(),
+			cancelado: getSwitchChecked("fechamento-contratacao-comprado") ? 0 : 1,
 		};
 		var request;
-		if (idx < 0) {
+		if (idx < 0 || contratacoes[idx].previsto === false) {
+			// Criação (idx<0) ou edição de item sem previsão: nome/área editáveis.
 			var nome = (document.getElementById("fechamento-contratacao-nome-item").value || "").trim();
 			if (!nome) { toast("Informe o nome do item.", "error"); return; }
 			dados.nome_item = nome;
 			dados.area = getSelectValue("fechamento-contratacao-area");
-			request = api("gris.api.festas.criar_contratacao_sem_previsao", { festa_name: festaName, dados_json: JSON.stringify(dados) });
+			request = idx < 0
+				? api("gris.api.festas.criar_contratacao_sem_previsao", { festa_name: festaName, dados_json: JSON.stringify(dados) })
+				: api("gris.api.festas.salvar_contratacao_sem_previsao", { contratacao_name: contratacoes[idx].name, dados_json: JSON.stringify(dados) });
 		} else {
 			request = api("gris.api.festas.salvar_realizado_contratacao", { contratacao_name: contratacoes[idx].name, dados_json: JSON.stringify(dados) });
 		}
@@ -4208,6 +4264,24 @@
 			.then(function () { toast("Fechamento salvo.", "success"); })
 			.catch(function (err) { toast(err.message || "Erro ao salvar.", "error"); })
 			.finally(function () { btn.disabled = false; });
+	}
+
+	function removerContratacaoFechamento() {
+		var dlg = document.getElementById("dialog-contratacao-fechamento");
+		var idx = parseInt(dlg.dataset.contratacaoIdx, 10);
+		if (!(idx >= 0)) return;
+		var c = contratacoes[idx];
+		confirmDialog({
+			title: "Remover item",
+			message: "Remover a contratação \"" + c.nome_item + "\"? Esta ação não pode ser desfeita.",
+			confirmLabel: "Remover",
+		}).then(function (ok) {
+			if (!ok) return;
+			api("gris.api.festas.excluir_contratacao", { contratacao_name: c.name, festa_name: festaName })
+				.then(function () { dlg.close(); return refreshFestaData(); })
+				.then(function () { toast("Item removido.", "success"); })
+				.catch(function (err) { toast(err.message || "Erro ao remover item.", "error"); });
+		});
 	}
 
 	// ── Barracas ──
@@ -4396,8 +4470,9 @@
 			return { label: b.nome_barraca || b.name, valor: Number(b.valor_arrecadado_realizado_real) || 0 };
 		});
 		var barracasTotal = barracasLinhas.reduce(function (s, r) { return s + r.valor; }, 0);
-		var comprasTotal = compras.reduce(function (s, c) { return s + (Number(c.valor_total_realizado) || 0); }, 0);
-		var contratacoesTotal = contratacoes.reduce(function (s, c) { return s + (Number(c.valor_total_realizado) || 0); }, 0);
+		// Itens cancelados (não comprados) não entram nas despesas.
+		var comprasTotal = compras.reduce(function (s, c) { return s + (c.cancelado ? 0 : Number(c.valor_total_realizado) || 0); }, 0);
+		var contratacoesTotal = contratacoes.reduce(function (s, c) { return s + (c.cancelado ? 0 : Number(c.valor_total_realizado) || 0); }, 0);
 		var entradas = convitesTotal + doacoes + barracasTotal;
 		var saidas = comprasTotal + contratacoesTotal;
 		return {
@@ -4596,6 +4671,11 @@
 		if (btnCompra) btnCompra.addEventListener("click", saveCompraFechamento);
 		var btnContr = document.getElementById("btn-fechamento-contratacao-salvar");
 		if (btnContr) btnContr.addEventListener("click", saveContratacaoFechamento);
+
+		var btnRemoverCompra = document.getElementById("btn-fechamento-compra-remover");
+		if (btnRemoverCompra) btnRemoverCompra.addEventListener("click", removerCompraFechamento);
+		var btnRemoverContr = document.getElementById("btn-fechamento-contratacao-remover");
+		if (btnRemoverContr) btnRemoverContr.addEventListener("click", removerContratacaoFechamento);
 	}
 
 	document.addEventListener("DOMContentLoaded", function () {

--- a/gris/www/festas/festa.py
+++ b/gris/www/festas/festa.py
@@ -167,6 +167,7 @@ def _hydrate_compra(doc, produto_labels: dict[str, str]) -> dict:
 		"valor_total_realizado": flt(doc.valor_total_realizado),
 		"fornecedor_realizado": doc.fornecedor_realizado or "",
 		"observacoes_realizado": doc.observacoes_realizado or "",
+		"cancelado": bool(doc.cancelado),
 		# Cenários de compra
 		"qtd_sugerida_min": flt(doc.qtd_sugerida_min),
 		"valor_total_min": flt(doc.valor_total_min),
@@ -210,6 +211,7 @@ def _hydrate_contratacao(doc) -> dict:
 		"valor_total_realizado": flt(doc.valor_total_realizado),
 		"fornecedor_realizado": doc.fornecedor_realizado or "",
 		"observacoes_realizado": doc.observacoes_realizado or "",
+		"cancelado": bool(doc.cancelado),
 		"cotacoes": [_hydrate_cotacao_contratacao(c) for c in (doc.cotacoes or [])],
 	}
 

--- a/gris/www/festas/relatorio.css
+++ b/gris/www/festas/relatorio.css
@@ -605,3 +605,20 @@
 		min-height: 260px;
 	}
 }
+
+/* Badge de item cancelado (não comprado) nas tabelas de compras/contratações. */
+.rel-badge {
+	display: inline-block;
+	padding: 0.05rem 0.4rem;
+	border-radius: var(--radius-md, 0.5rem);
+	font-size: 0.7rem;
+	font-weight: 600;
+	line-height: 1.4;
+	white-space: nowrap;
+	vertical-align: middle;
+}
+
+.rel-badge--cancelado {
+	background: var(--destructive, #dc2626);
+	color: #fff;
+}

--- a/gris/www/festas/relatorio.html
+++ b/gris/www/festas/relatorio.html
@@ -325,7 +325,7 @@
 			<tbody>
 				{% for c in compras %}
 				<tr>
-					<td>{{ c.nome_item }}</td>
+					<td>{{ c.nome_item }}{% if c.cancelado %} <span class="rel-badge rel-badge--cancelado">Cancelado</span>{% endif %}</td>
 					<td class="rel-num">{{ brl(c.valor_individual_orcado) }}</td>
 					<td class="rel-num">{{ qty(c.qtd_orcada) }}</td>
 					<td class="rel-num">{{ brl(c.valor_total_orcado) }}</td>
@@ -368,7 +368,7 @@
 			<tbody>
 				{% for c in contratacoes %}
 				<tr>
-					<td>{{ c.nome_item }}</td>
+					<td>{{ c.nome_item }}{% if c.cancelado %} <span class="rel-badge rel-badge--cancelado">Cancelado</span>{% endif %}</td>
 					<td class="rel-num">{{ brl(c.valor_orcado) }}</td>
 					<td>{{ c.fornecedor_orcado }}</td>
 					<td class="rel-num">{{ brl(c.valor_realizado) }}</td>


### PR DESCRIPTION
This pull request introduces a "cancelado" (canceled/not purchased) flag for purchases and contracts in the Festa system. This flag allows users to mark items as canceled, ensures canceled items are excluded from expense reports, and updates both the backend logic and the UI to handle and display this new status. Additionally, new tests have been added to ensure correct behavior for canceled items.

**Support for canceled items in purchases and contracts:**

* Added a `cancelado` field (boolean) to both `Compra Festa` and `Contratacao Festa` doctypes, including schema updates and UI elements for marking items as canceled. [[1]](diffhunk://#diff-dfc05d408b90d85734b16785b41fc87be64f04408d9e746df58852ab3542d9f2L47-R48) [[2]](diffhunk://#diff-dfc05d408b90d85734b16785b41fc87be64f04408d9e746df58852ab3542d9f2R284-R289) [[3]](diffhunk://#diff-ebef1f305b2e6b408408acc452f1dc7e56127252f1481b3cb91f549d6928181fL20-R21) [[4]](diffhunk://#diff-ebef1f305b2e6b408408acc452f1dc7e56127252f1481b3cb91f549d6928181fR93-R98)
* Updated hydration and application functions to read and write the `cancelado` flag for both purchases and contracts, ensuring the flag is persisted and returned in API responses. [[1]](diffhunk://#diff-42336687f97b7954926d794f3f1f743b4e027a6fdf8686c3984ce81310ac24d7R783) [[2]](diffhunk://#diff-42336687f97b7954926d794f3f1f743b4e027a6fdf8686c3984ce81310ac24d7R954) [[3]](diffhunk://#diff-42336687f97b7954926d794f3f1f743b4e027a6fdf8686c3984ce81310ac24d7R1051) [[4]](diffhunk://#diff-42336687f97b7954926d794f3f1f743b4e027a6fdf8686c3984ce81310ac24d7R1060)

**API and business logic changes:**

* Introduced new whitelisted endpoints for updating "sem previsão" (unplanned) purchases and contracts, with validation to prevent editing planned items and to handle the `cancelado` flag. [[1]](diffhunk://#diff-42336687f97b7954926d794f3f1f743b4e027a6fdf8686c3984ce81310ac24d7R1125-R1150) [[2]](diffhunk://#diff-42336687f97b7954926d794f3f1f743b4e027a6fdf8686c3984ce81310ac24d7R1184-R1204)
* Updated report-building logic to include the `cancelado` flag in the output, and to ensure canceled items are excluded from total expenses and area breakdowns in reports. [[1]](diffhunk://#diff-be3ab0519723f01d6af9fafa641769dcde57271ff700b9d2a9b68c9bc57c7b83R389) [[2]](diffhunk://#diff-be3ab0519723f01d6af9fafa641769dcde57271ff700b9d2a9b68c9bc57c7b83R404) [[3]](diffhunk://#diff-be3ab0519723f01d6af9fafa641769dcde57271ff700b9d2a9b68c9bc57c7b83R427) [[4]](diffhunk://#diff-be3ab0519723f01d6af9fafa641769dcde57271ff700b9d2a9b68c9bc57c7b83R439-R453)

**UI/UX improvements:**

* Added visual badges in both the HTML (PDF) and web UI to clearly indicate canceled items, including new CSS for the canceled badge and updates to item tables. [[1]](diffhunk://#diff-e2a1513f5e1c1163508e95df2bd5c898cfd0659f0d290452d3f9f51fad62aa87L111-R111) [[2]](diffhunk://#diff-e2a1513f5e1c1163508e95df2bd5c898cfd0659f0d290452d3f9f51fad62aa87L137-R137) [[3]](diffhunk://#diff-e2a1513f5e1c1163508e95df2bd5c898cfd0659f0d290452d3f9f51fad62aa87R295-R296) [[4]](diffhunk://#diff-bd09460a27b17834fb851ce56a05996dc3296af3d20319a7db3c6b902abcb70bR878-R888) [[5]](diffhunk://#diff-0db0055c671695197d15e8b5cabe80677c2ec17e5b72e5b755a44ab44659ce21R3907) [[6]](diffhunk://#diff-0db0055c671695197d15e8b5cabe80677c2ec17e5b72e5b755a44ab44659ce21L3928-R3929)
* Updated the item detail dialogs to include a switch for marking an item as purchased/canceled and a "Remover item" button. [[1]](diffhunk://#diff-d9caf501933c07167765b7a2d57e9a9b2432f6af57bc728b0c6111b8061a00dbR1821-R1823) [[2]](diffhunk://#diff-d9caf501933c07167765b7a2d57e9a9b2432f6af57bc728b0c6111b8061a00dbR1860) [[3]](diffhunk://#diff-d9caf501933c07167765b7a2d57e9a9b2432f6af57bc728b0c6111b8061a00dbR1906-R1908) [[4]](diffhunk://#diff-d9caf501933c07167765b7a2d57e9a9b2432f6af57bc728b0c6111b8061a00dbR1923)

**Testing:**

* Added comprehensive tests for the new functionality, including creation, editing, and removal of canceled items, validation for disallowed operations, and checks that canceled items do not affect reported expenses. [[1]](diffhunk://#diff-9b2596ab55b3f16bb8c596da679c18ddc7cbdaf3550b6258f668c86d1ee5cf8fR1-R15) [[2]](diffhunk://#diff-9b2596ab55b3f16bb8c596da679c18ddc7cbdaf3550b6258f668c86d1ee5cf8fR124-R183) [[3]](diffhunk://#diff-9218dc9bd379664ed873f67be604aee95c736f053d0a5772ff670c2621d2c560R1-R86)