### PR TITLE
Corrige permissão de criação de eventos no calendário

### DIFF
--- a/gris/fixtures/role.json
+++ b/gris/fixtures/role.json
@@ -258,5 +258,18 @@
   "restrict_to_domain": null,
   "role_name": "Equipe de Metodos",
   "two_factor_auth": 0
+ },
+ {
+  "desk_access": 1,
+  "disabled": 0,
+  "docstatus": 0,
+  "doctype": "Role",
+  "home_page": null,
+  "is_custom": 0,
+  "modified": "2026-07-08 00:00:00",
+  "name": "Editor Calendario",
+  "restrict_to_domain": null,
+  "role_name": "Editor Calendario",
+  "two_factor_auth": 0
  }
 ]

--- a/gris/gris/doctype/calendario/calendario.json
+++ b/gris/gris/doctype/calendario/calendario.json
@@ -112,6 +112,20 @@
    "role": "Equipe de Metodos",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "Editor Calendario",
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "Gestor Calendario",
+   "write": 1
   }
  ],
  "row_format": "Dynamic",

--- a/gris/gris/doctype/calendario_simulado/calendario_simulado.json
+++ b/gris/gris/doctype/calendario_simulado/calendario_simulado.json
@@ -86,6 +86,20 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "Editor Calendario",
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "Gestor Calendario",
+   "write": 1
   }
  ],
  "row_format": "Dynamic",

--- a/gris/hooks.py
+++ b/gris/hooks.py
@@ -339,6 +339,7 @@ fixtures = [
 					"Acesso ao Desk",
 					"Visualizador Calendario",
 					"Gestor Calendario",
+					"Editor Calendario",
 					"Recepcao",
 					"Responsavel",
 					"Gestor de festas",

--- a/gris/public/design_system/components/generated/calendar.html.jinja
+++ b/gris/public/design_system/components/generated/calendar.html.jinja
@@ -35,10 +35,14 @@
 
   Eventos disparados (no elemento root):
     - "gris:calendar:event-click" → detail = { id, title, start, end, category, data }.
+    - "gris:calendar:day-click"   → detail = { date } (YYYY-MM-DD). Disparado ao
+        clicar no espaço vazio de um dia, em qualquer modo (mês, semana, lista).
 
   API pública (no elemento root):
     - el.events (getter/setter)              re-renderiza ao setar
     - el.activeCategories (getter/setter)    sincroniza categorias/filtros ativos
+    - el.setCategories([{name,label,color}]) substitui as categorias (recria os
+        filtros; novas categorias entram ativas) e re-renderiza
     - el.setMode("month" | "week" | "list")
     - el.setListVariant("default" | "category")
     - el.setListShowAllDays(boolean)

--- a/gris/public/design_system/js/components/calendar.js
+++ b/gris/public/design_system/js/components/calendar.js
@@ -779,6 +779,7 @@
               isToday ? "calendar__week-day-column--today" : "",
             ].filter(Boolean).join(" "),
             style: { height: `${totalHeight}px` },
+            attrs: { "data-calendar-day": formatISODate(dayDate) },
           });
           for (let h = hourRange[0] + 1; h < hourRange[1]; h += 1) {
             dayCol.appendChild(el("div", {
@@ -861,6 +862,7 @@
               isWeekend ? "calendar__week-stacked-cell--weekend" : "calendar__week-stacked-cell--weekday",
               isToday ? "calendar__week-stacked-cell--today" : "",
             ].filter(Boolean).join(" "),
+            attrs: { "data-calendar-day": formatISODate(dayDate) },
           });
 
           const dayItems = stackedEvents
@@ -1168,14 +1170,18 @@
       });
     }
 
-    root.querySelectorAll("[data-calendar-filter]").forEach((cb) => {
-      cb.addEventListener("change", () => {
+    // Delegação no wrapper de filtros para sobreviver à recriação dos checkboxes
+    // quando `setCategories` é chamado (ex.: atualização in-place de eventos).
+    if (filtersWrap) {
+      filtersWrap.addEventListener("change", (event) => {
+        const cb = event.target.closest("[data-calendar-filter]");
+        if (!cb) return;
         if (cb.checked) activeCategories.add(cb.value);
         else activeCategories.delete(cb.value);
         updateFiltersCount();
         render();
       });
-    });
+    }
 
     const allBtn = root.querySelector("[data-calendar-filters-all]");
     const noneBtn = root.querySelector("[data-calendar-filters-none]");
@@ -1224,21 +1230,35 @@
     // Click delegation: dispatch CustomEvent
     body.addEventListener("click", (event) => {
       const card = event.target.closest("[data-calendar-event-id]");
-      if (!card) return;
-      const eventId = card.getAttribute("data-calendar-event-id");
-      const found = events.find((e) => String(e.id) === String(eventId));
-      if (!found) return;
-      root.dispatchEvent(new CustomEvent("gris:calendar:event-click", {
+      if (card) {
+        const eventId = card.getAttribute("data-calendar-event-id");
+        const found = events.find((e) => String(e.id) === String(eventId));
+        if (!found) return;
+        root.dispatchEvent(new CustomEvent("gris:calendar:event-click", {
+          bubbles: true,
+          detail: {
+            id: found.id,
+            title: found.title,
+            start: found.raw.start,
+            end: found.raw.end,
+            all_day: found.allDay,
+            category: found.category,
+            data: found.data,
+          },
+        }));
+        return;
+      }
+
+      // Clique em espaço vazio de um dia → dispara "day-click" com a data (YYYY-MM-DD).
+      // Ignora cliques dentro do popover "+N" (o botão "+N" já usa stopPropagation).
+      if (event.target.closest(".calendar__more-popover")) return;
+      const dayEl = event.target.closest("[data-calendar-day]");
+      if (!dayEl) return;
+      const date = dayEl.getAttribute("data-calendar-day");
+      if (!date) return;
+      root.dispatchEvent(new CustomEvent("gris:calendar:day-click", {
         bubbles: true,
-        detail: {
-          id: found.id,
-          title: found.title,
-          start: found.raw.start,
-          end: found.raw.end,
-          all_day: found.allDay,
-          category: found.category,
-          data: found.data,
-        },
+        detail: { date },
       }));
     });
 
@@ -1319,6 +1339,54 @@
 
     root.setActiveCategories = (names) => {
       root.activeCategories = names;
+    };
+
+    // Recria os checkboxes de filtro no popover a partir do array `categories`
+    // atual, preservando o estado (marcado/desmarcado) via `activeCategories`.
+    const rebuildFilterOptions = () => {
+      if (!filtersWrap) return;
+      const popover = filtersWrap.querySelector(".calendar__filters-popover");
+      if (!popover) return;
+      popover.querySelectorAll(".calendar__filter").forEach((node) => node.remove());
+      for (const cat of categories) {
+        const input = el("input", {
+          attrs: { type: "checkbox", "data-calendar-filter": "", value: cat.name },
+        });
+        input.checked = activeCategories.has(cat.name);
+        const swatch = el("span", {
+          class: "calendar__filter-swatch",
+          attrs: { "aria-hidden": "true" },
+          style: { "--cal-cat-color": cat.color || "var(--primary)" },
+        });
+        const label = el("span", { class: "calendar__filter-label", text: cat.label || cat.name });
+        popover.appendChild(el("label", { class: "calendar__filter" }, [input, swatch, label]));
+      }
+    };
+
+    root.setCategories = (nextCategories) => {
+      const list = Array.isArray(nextCategories)
+        ? nextCategories.filter((c) => c && c.name)
+        : [];
+      const previouslyKnown = new Set(categoryMap.keys());
+
+      categories.length = 0;
+      categoryMap.clear();
+      for (const cat of list) {
+        categories.push(cat);
+        categoryMap.set(cat.name, cat);
+      }
+
+      // Remove filtros ativos de categorias que sumiram; ativa as novas por padrão.
+      for (const name of Array.from(activeCategories)) {
+        if (!categoryMap.has(name)) activeCategories.delete(name);
+      }
+      for (const cat of list) {
+        if (!previouslyKnown.has(cat.name)) activeCategories.add(cat.name);
+      }
+
+      rebuildFilterOptions();
+      updateFiltersCount();
+      render();
     };
 
     root.goToDate = (iso) => {

--- a/gris/www/calendario/simulacao_calendario.css
+++ b/gris/www/calendario/simulacao_calendario.css
@@ -223,6 +223,32 @@
     scroll-padding-block: 6rem;
 }
 
+/* Affordance de "clique para criar evento": as áreas de dia clicáveis (mês, semana
+ * e lista) ganham cursor de ponteiro e um leve destaque no hover. Casa com o
+ * listener de `gris:calendar:day-click` no JS desta página. */
+.simulation-calendar .calendar__day-cell,
+.simulation-calendar .calendar__week-stacked-cell,
+.simulation-calendar .calendar__week-day-column,
+.simulation-calendar .calendar__list-day,
+.simulation-calendar .calendar__list-category-row {
+    cursor: pointer;
+    transition: background-color 0.12s ease;
+}
+
+.simulation-calendar .calendar__day-cell:hover,
+.simulation-calendar .calendar__week-stacked-cell:hover,
+.simulation-calendar .calendar__week-day-column:hover,
+.simulation-calendar .calendar__list-day:hover,
+.simulation-calendar .calendar__list-category-row:hover {
+    background-color: color-mix(in oklch, var(--accent) 70%, transparent);
+}
+
+/* Os cards de evento mantêm o próprio cursor/hover (são botões de edição). */
+.simulation-calendar .calendar-event-card,
+.simulation-calendar .calendar__list-event {
+    cursor: pointer;
+}
+
 .simulation-table-wrap {
     overflow-x: auto;
     border: 1px solid var(--border);

--- a/gris/www/calendario/simulacao_calendario.js
+++ b/gris/www/calendario/simulacao_calendario.js
@@ -148,6 +148,45 @@ function reloadPage() {
     window.location.reload();
 }
 
+// Atualiza o calendário in-place após uma mutação (criar/editar/excluir), sem
+// recarregar a página: rebusca os eventos/categorias serializados do servidor e os
+// aplica ao componente, preservando a posição de scroll (a lista rola dentro de
+// `[data-calendar-body]`, não na janela). Se algo falhar, cai para o reload completo.
+function refreshCalendarEvents() {
+    const calendarRoot = document.getElementById("simulation-calendar");
+    if (!calendarRoot || typeof calendarRoot.setCategories !== "function") {
+        reloadPage();
+        return;
+    }
+
+    frappe.call({
+        method: "gris.www.calendario.simulacao_calendario.get_calendar_events",
+        args: { year: getSelectedYear() },
+        callback(result) {
+            const payload = result.message || {};
+            if (!Array.isArray(payload.events)) {
+                reloadPage();
+                return;
+            }
+
+            const calendarBody = calendarRoot.querySelector("[data-calendar-body]");
+            const bodyTop = calendarBody ? calendarBody.scrollTop : 0;
+            const windowY = window.scrollY || 0;
+
+            if (Array.isArray(payload.categories)) {
+                calendarRoot.setCategories(payload.categories);
+            }
+            calendarRoot.events = payload.events; // re-render síncrono
+
+            if (calendarBody) calendarBody.scrollTop = bodyTop;
+            window.scrollTo(0, windowY);
+        },
+        error() {
+            reloadPage();
+        },
+    });
+}
+
 function applySemAtividadeState(checkboxEl, localEl, levelFieldId) {
     const isSemAtividade = checkboxEl ? checkboxEl.checked : false;
     if (localEl) {
@@ -338,6 +377,12 @@ function resetNewEventForm(defaultDate, selectedSection) {
     applyAberturaGeralState(aberturaGeralInput, atividadeInput);
 }
 
+function openNewEventDialogForDate(date) {
+    if (!document.getElementById("new-activity-modal")) return;
+    resetNewEventForm(date || getDefaultEventDate(), null);
+    openDialogById("new-activity-modal");
+}
+
 function initNewEventDialog() {
     const dialog = document.getElementById("new-activity-modal");
     if (!dialog) return;
@@ -360,8 +405,7 @@ function initNewEventDialog() {
     });
 
     newEventButton?.addEventListener("click", () => {
-        resetNewEventForm(getDefaultEventDate(), null);
-        openDialogById("new-activity-modal");
+        openNewEventDialogForDate(getDefaultEventDate());
     });
 
     cancelButton?.addEventListener("click", () => closeDialogById("new-activity-modal"));
@@ -404,7 +448,7 @@ function initNewEventDialog() {
                 if (result.message?.success) {
                     closeDialogById("new-activity-modal");
                     frappe.show_alert({ message: result.message.message, indicator: "green" });
-                    reloadPage();
+                    refreshCalendarEvents();
                     return;
                 }
                 showApiError(result, "Erro ao criar o evento simulado.");
@@ -500,7 +544,7 @@ function initEditEventDialog() {
                 if (result.message?.success) {
                     closeDialogById("edit-activity-modal");
                     frappe.show_alert({ message: result.message.message, indicator: "green" });
-                    reloadPage();
+                    refreshCalendarEvents();
                     return;
                 }
                 showApiError(result, "Erro ao atualizar o evento.");
@@ -558,7 +602,7 @@ function initDeleteEventDialog() {
             callback(result) {
                 if (result.message?.success) {
                     frappe.show_alert({ message: result.message.message, indicator: "green" });
-                    reloadPage();
+                    refreshCalendarEvents();
                     return;
                 }
                 showApiError(result, "Erro ao excluir o evento.");
@@ -588,6 +632,14 @@ function initCalendarInteractions() {
         if (data.event_type === "simulation" && document.getElementById("edit-activity-modal")) {
             openEditDialog(data);
         }
+    });
+
+    // Clique em espaço vazio de um dia (qualquer visualização) abre o diálogo de
+    // novo evento já com a data clicada preenchida.
+    calendarRoot.addEventListener("gris:calendar:day-click", (event) => {
+        const date = event.detail?.date;
+        if (!date) return;
+        openNewEventDialogForDate(date);
     });
 }
 

--- a/gris/www/calendario/simulacao_calendario.py
+++ b/gris/www/calendario/simulacao_calendario.py
@@ -297,6 +297,75 @@ def _validate_activity_flags(sem_atividade, abertura_geral):
 
 
 @frappe.whitelist()
+def get_calendar_events(year=None):
+	"""Retorna os eventos serializados + categorias do calendário simulado do ano.
+
+	Usado para atualização in-place no cliente após criar/editar/excluir um evento,
+	evitando recarregar a página inteira. Espelha a montagem de `calendar_events` e
+	`calendar_categories` feita em `get_context`, reaproveitando os mesmos helpers de
+	serialização e cor para não haver divergência.
+	"""
+	try:
+		year = int(year)
+	except (ValueError, TypeError):
+		year = getdate(today()).year
+
+	if not frappe.has_permission("Calendario", "write"):
+		frappe.throw(_("Permissão negada"), frappe.PermissionError)
+
+	feriados = frappe.get_all(
+		"Feriados",
+		filters={"data": ["between", [f"{year}-01-01", f"{year}-12-31"]]},
+		fields=["nome", "data", "tipo", "descricao"],
+	)
+
+	events = frappe.get_all(
+		"Calendario Simulado",
+		filters={"inicio": ["<=", f"{year}-12-31 23:59:59"], "termino": [">=", f"{year}-01-01 00:00:00"]},
+		fields=[
+			"name",
+			"atividade",
+			"inicio",
+			"termino",
+			"secao",
+			"local",
+			"sem_atividade",
+			"abertura_geral",
+			"nivel",
+		],
+		order_by="inicio asc",
+	)
+
+	associados = frappe.get_all("Associado", fields=["secao", "ramo"], distinct=True)
+	section_ramo_map = {d.secao: d.ramo for d in associados if d.secao}
+
+	sections = {event.secao if event.secao else "Diretoria" for event in events}
+	ramo_order = ["Diretoria", "Filhotes", "Lobinho", "Escoteiro", "Sênior", "Pioneiro"]
+	sorted_sections = sorted(
+		list(sections), key=lambda s: _get_section_sort_key(s, section_ramo_map, ramo_order)
+	)
+
+	section_colors = {s: _get_section_color(s, section_ramo_map) for s in sorted_sections}
+	categories = [{"name": s, "label": s, "color": section_colors[s]} for s in sorted_sections]
+	if feriados:
+		categories.append(
+			{"name": HOLIDAY_CATEGORY_NAME, "label": "Feriados", "color": HOLIDAY_CATEGORY_COLOR}
+		)
+
+	serialized_events = [
+		_serialize_simulated_event(event, section_colors.get(event.secao or "Diretoria", SECTION_COLOR_BY_RAMO["default"]))
+		for event in events
+	]
+	serialized_holidays = [_serialize_holiday_event(holiday) for holiday in feriados]
+	calendar_events = sorted(
+		serialized_events + serialized_holidays,
+		key=lambda item: (item.get("start") or "", item.get("title") or ""),
+	)
+
+	return {"events": calendar_events, "categories": categories}
+
+
+@frappe.whitelist()
 def get_reconciliation_data(year=None):
 	if not year:
 		year = getdate(today()).year


### PR DESCRIPTION
This pull request introduces significant improvements to the simulated calendar functionality, focusing on enhancing the in-place update experience, improving interactivity for event creation, and expanding role-based access. The main changes include implementing in-place calendar updates after event mutations, enabling users to create events by clicking on empty calendar days, and updating permissions and roles to support new editor functionalities.

**Calendar interactivity and UX improvements:**

* Added support for clicking on empty days in any calendar view to open the "new event" dialog pre-filled with the selected date, by dispatching a custom `gris:calendar:day-click` event from the calendar component and handling it in the simulation page JS. Also updated calendar cells to show a pointer cursor and highlight on hover for better affordance. [[1]](diffhunk://#diff-5dce32dbdd79ecf1dfe6a2ad7441b0f988dd09c96ccd03f15ba5a37dc944ed57R782) [[2]](diffhunk://#diff-5dce32dbdd79ecf1dfe6a2ad7441b0f988dd09c96ccd03f15ba5a37dc944ed57R865) [[3]](diffhunk://#diff-5dce32dbdd79ecf1dfe6a2ad7441b0f988dd09c96ccd03f15ba5a37dc944ed57R1249-R1262) [[4]](diffhunk://#diff-dbd33aa3ee25b21ce6a6644ff71f2777030682d59d8cf6bbe9ac840b3d8da8dbR226-R251) [[5]](diffhunk://#diff-9685a47406be2ff5cf0deadaedd6eade3155e83a68efdeccc43560e02e1ee7b6R636-R643)

* Improved filter management in the calendar component by delegating filter checkbox change events to the wrapper and rebuilding filter options dynamically, ensuring filter state is preserved during in-place updates. [[1]](diffhunk://#diff-5dce32dbdd79ecf1dfe6a2ad7441b0f988dd09c96ccd03f15ba5a37dc944ed57L1171-R1184) [[2]](diffhunk://#diff-5dce32dbdd79ecf1dfe6a2ad7441b0f988dd09c96ccd03f15ba5a37dc944ed57R1344-R1391)

**In-place calendar updates:**

* Implemented a new backend endpoint `get_calendar_events` to fetch the latest events and categories for the simulated calendar, and a corresponding frontend function `refreshCalendarEvents` to update the calendar in-place after creating, editing, or deleting events, preserving scroll position and avoiding full page reloads. [[1]](diffhunk://#diff-447ecb48723f9680fb2fdabca8ef5b9e6bade3e45e77e014499d8b00e01d564fR299-R367) [[2]](diffhunk://#diff-9685a47406be2ff5cf0deadaedd6eade3155e83a68efdeccc43560e02e1ee7b6R151-R189) [[3]](diffhunk://#diff-9685a47406be2ff5cf0deadaedd6eade3155e83a68efdeccc43560e02e1ee7b6R380-R385) [[4]](diffhunk://#diff-9685a47406be2ff5cf0deadaedd6eade3155e83a68efdeccc43560e02e1ee7b6L407-R451) [[5]](diffhunk://#diff-9685a47406be2ff5cf0deadaedd6eade3155e83a68efdeccc43560e02e1ee7b6L503-R547) [[6]](diffhunk://#diff-9685a47406be2ff5cf0deadaedd6eade3155e83a68efdeccc43560e02e1ee7b6L561-R605)

**Role and permission management:**

* Added a new role `Editor Calendario` to the fixtures and included it in the list of roles with access to the system. Updated permissions for `Calendario` and `Calendario Simulado` doctypes to grant full CRUD access to both `Editor Calendario` and `Gestor Calendario`. [[1]](diffhunk://#diff-3e73e1e0b286b02c3a332a1f2883f8543e2dd3048d2bfc0977225910ec988665R261-R273) [[2]](diffhunk://#diff-9e92f2570b61bad967c6c620373ea4fed8ec2f17b38d209facfb590f6272bf41R342) [[3]](diffhunk://#diff-b5265a2d991470a5cb338e0564f86c4513a2ac14340cfcddbcfb2f9faf428d96R115-R128) [[4]](diffhunk://#diff-4d5575e58fb51380a484f4bd793826371940de5b4352e87a4caed10bc729ad21R89-R102)