### PR TITLE
fix: preserva papéis de usuários na importação de associados

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,9 @@ Ao trabalhar em tarefas específicas, consulte a skill correspondente em `.claud
 - Endpoint sem validação de acesso
 - SQL sem parâmetros
 - Usar `frappe.cache`
+- Gravar `User.role_profile_name` (ou chamar `User.save()` / `add_roles()`) em rotinas
+  automáticas: o Frappe repopula `roles` a partir do perfil e remove papéis concedidos
+  manualmente. Use os utilitários de `gris/api/users/roles.py`
 - Regra de negócio extensa dentro de handlers de UI
 - Logs permanentes ruidosos sem valor operacional
 

--- a/gris/api/associate/importer.py
+++ b/gris/api/associate/importer.py
@@ -9,6 +9,8 @@ import frappe
 import pandas as pd
 import pdfplumber
 
+from gris.api.users.roles import add_user_roles
+
 
 def _extract_text_from_pdf(pdf_path: str) -> str:
 	"""Extrai texto completo do PDF utilizando pdfplumber"""
@@ -368,16 +370,12 @@ def _upsert_portal_user(
 		user.insert()
 		action = "created"
 	else:
-		# Usuário já existe — apenas garante (de forma aditiva) que o papel
-		# Responsavel está atribuído. NÃO alteramos role_profile_name (Função),
-		# pois isso substituiria o perfil existente e removeria acessos de
-		# usuários que já são responsáveis e também têm outras funções.
+		# Usuário já existe — apenas concede (de forma aditiva) o papel
+		# Responsavel. NÃO alteramos role_profile_name (Função) nem usamos
+		# User.save(): ambos fazem o Frappe repopular a lista de papéis a partir
+		# do perfil, removendo acessos concedidos manualmente ao usuário.
 		if responsavel_name:
-			user_doc = frappe.get_doc("User", email)
-			existing_roles = {r.role for r in user_doc.roles}
-			if "Responsavel" not in existing_roles:
-				user_doc.append("roles", {"role": "Responsavel"})
-				user_doc.save(ignore_permissions=True)
+			add_user_roles(email, ["Responsavel"])
 
 	# Garante que Responsavel.email aponte para este usuário (exigido pelo portal).
 	if responsavel_name and frappe.db.exists("Responsavel", responsavel_name):

--- a/gris/api/users/roles.py
+++ b/gris/api/users/roles.py
@@ -1,0 +1,213 @@
+"""Utilitários para concessão e troca de papéis (roles) de usuários.
+
+Motivação: no Frappe, gravar `User.role_profile_name` faz o framework
+**substituir toda a lista de papéis** do usuário pelos papéis do perfil —
+`populate_role_profile_roles()` limpa `roles` antes de repopular. Consequência:
+qualquer papel concedido manualmente (ex.: "Acesso ao Desk", "Responsavel",
+"Portaria") é silenciosamente removido em qualquer `User.save()` disparado por
+uma rotina automática, como a importação de associados.
+
+As funções abaixo permitem:
+
+* conceder papéis de forma **aditiva**, sem passar por `User.save()`
+  (`add_user_roles`);
+* trocar o Role Profile **preservando** os papéis que não vieram do perfil
+  anterior, isto é, as concessões manuais (`apply_role_profile`).
+"""
+
+import json
+
+import frappe
+from frappe.utils import add_days, cint, now_datetime
+
+# Perfil sem nenhum papel associado. Usado como "sem mapeamento" na criação de
+# usuários; nunca deve ser aplicado automaticamente sobre um usuário existente,
+# pois zeraria todos os acessos.
+PERFIL_SEM_ACESSO = "Guest"
+
+
+def get_role_profile_roles(role_profile: str | None) -> set[str]:
+	"""Retorna o conjunto de papéis de um Role Profile (vazio se não existir)."""
+	if not role_profile or not frappe.db.exists("Role Profile", role_profile):
+		return set()
+
+	return set(
+		frappe.get_all(
+			"Has Role",
+			filters={"parenttype": "Role Profile", "parent": role_profile},
+			pluck="role",
+			limit_page_length=0,
+		)
+	)
+
+
+def get_user_roles(user: str) -> set[str]:
+	"""Retorna o conjunto de papéis atualmente atribuídos ao usuário."""
+	if not user:
+		return set()
+
+	return set(
+		frappe.get_all(
+			"Has Role",
+			filters={"parenttype": "User", "parent": user},
+			pluck="role",
+			limit_page_length=0,
+		)
+	)
+
+
+def add_user_roles(user: str, roles) -> list[str]:
+	"""Concede papéis ao usuário sem disparar `User.save()`.
+
+	As linhas de `Has Role` são gravadas diretamente para que o framework não
+	recalcule a lista de papéis a partir do `role_profile_name` — o que
+	removeria papéis concedidos manualmente.
+
+	Retorna a lista de papéis efetivamente adicionados.
+	"""
+	if not user or not roles:
+		return []
+
+	# Remove duplicados e vazios preservando a ordem informada.
+	roles = [role for role in dict.fromkeys(roles) if role]
+	if not roles:
+		return []
+
+	existentes = get_user_roles(user)
+	papeis_validos = set(
+		frappe.get_all("Role", filters={"name": ("in", roles)}, pluck="name", limit_page_length=0)
+	)
+
+	ultima_linha = frappe.get_all(
+		"Has Role",
+		filters={"parenttype": "User", "parent": user},
+		fields=["idx"],
+		order_by="idx desc",
+		limit=1,
+	)
+	proximo_idx = (ultima_linha[0].idx if ultima_linha else 0) or 0
+
+	adicionados = []
+	for role in roles:
+		if role in existentes or role not in papeis_validos:
+			continue
+
+		proximo_idx += 1
+		frappe.get_doc(
+			{
+				"doctype": "Has Role",
+				"parent": user,
+				"parenttype": "User",
+				"parentfield": "roles",
+				"idx": proximo_idx,
+				"role": role,
+			}
+		).insert(ignore_permissions=True)
+		adicionados.append(role)
+
+	if adicionados:
+		frappe.clear_cache(user=user)
+
+	return adicionados
+
+
+def save_user_preserving_roles(user_doc, ignore_permissions: bool = True) -> list[str]:
+	"""Grava o usuário reaplicando os papéis descartados pelo recálculo do perfil.
+
+	Qualquer `User.save()` faz o Frappe repopular `roles` a partir de
+	`role_profile_name`, descartando papéis concedidos manualmente — mesmo
+	quando a gravação nada tem a ver com papéis (ex.: ativar/desativar o
+	usuário). Esta função restaura esses papéis logo após a gravação.
+
+	Retorna a lista de papéis que precisaram ser restaurados.
+	"""
+	papeis_antes = set() if user_doc.get("__islocal") else get_user_roles(user_doc.name)
+
+	user_doc.save(ignore_permissions=ignore_permissions)
+
+	return add_user_roles(user_doc.name, sorted(papeis_antes - get_user_roles(user_doc.name)))
+
+
+def apply_role_profile(user_doc, novo_perfil: str) -> dict:
+	"""Troca o Role Profile do usuário preservando os papéis concedidos manualmente.
+
+	Papéis que o usuário possui e que **não** fazem parte do perfil anterior são
+	tratados como concessão manual e reaplicados após a troca, já que o Frappe
+	zera a lista de papéis ao gravar `role_profile_name`.
+
+	Retorna um resumo com o perfil anterior, o novo e os papéis preservados.
+	"""
+	perfil_anterior = user_doc.role_profile_name
+	papeis_manuais = get_user_roles(user_doc.name) - get_role_profile_roles(perfil_anterior)
+
+	user_doc.role_profile_name = novo_perfil
+	user_doc.save(ignore_permissions=True)
+
+	preservados = add_user_roles(user_doc.name, sorted(papeis_manuais))
+
+	return {
+		"perfil_anterior": perfil_anterior,
+		"perfil_novo": novo_perfil,
+		"papeis_preservados": preservados,
+	}
+
+
+@frappe.whitelist()
+def diagnosticar_papeis_removidos(email: str | None = None, dias: int = 90, aplicar: int = 0) -> dict:
+	"""Lista (e opcionalmente restaura) papéis removidos automaticamente de usuários.
+
+	Usa o histórico de versões (`Version`) do DocType User para identificar
+	papéis que foram retirados — tipicamente pelo recálculo do Role Profile em
+	rotinas automáticas, como a importação de associados — e que o usuário ainda
+	não possui.
+
+	Por padrão roda em modo simulação (`aplicar=0`), para que a restauração seja
+	conferida antes de ser aplicada.
+	"""
+	if "System Manager" not in frappe.get_roles(frappe.session.user):
+		frappe.throw("Sem permissão para diagnosticar papéis de usuários.", frappe.PermissionError)
+
+	aplicar = cint(aplicar)
+	dias = cint(dias) or 90
+
+	filtros = {
+		"ref_doctype": "User",
+		"creation": (">=", add_days(now_datetime(), -dias)),
+	}
+	if email:
+		filtros["docname"] = email
+
+	versoes = frappe.get_all(
+		"Version",
+		filters=filtros,
+		fields=["docname", "data"],
+		order_by="creation asc",
+		limit_page_length=0,
+	)
+
+	removidos: dict[str, set[str]] = {}
+	for versao in versoes:
+		try:
+			dados = json.loads(versao.data or "{}")
+		except ValueError:
+			continue
+
+		for parentfield, linha in dados.get("removed") or []:
+			if parentfield != "roles":
+				continue
+			papel = (linha or {}).get("role")
+			if papel:
+				removidos.setdefault(versao.docname, set()).add(papel)
+
+	resultado = {"usuarios": [], "aplicado": bool(aplicar)}
+	for usuario, papeis in sorted(removidos.items()):
+		pendentes = sorted(papeis - get_user_roles(usuario))
+		if not pendentes:
+			continue
+
+		restaurados = add_user_roles(usuario, pendentes) if aplicar else []
+		resultado["usuarios"].append(
+			{"usuario": usuario, "papeis_removidos": pendentes, "papeis_restaurados": restaurados}
+		)
+
+	return resultado

--- a/gris/api/users/user_manager.py
+++ b/gris/api/users/user_manager.py
@@ -3,6 +3,8 @@ import uuid
 import frappe
 from frappe.utils import cint
 
+from gris.api.users.roles import PERFIL_SEM_ACESSO, apply_role_profile, save_user_preserving_roles
+
 
 def _logger():
 	return frappe.logger("associate_user", allow_site=True, file_count=10)
@@ -107,23 +109,34 @@ def _associate_users_to_deactivate(associates, users):
 	return users_to_deactivate
 
 
+def _define_role_profile_por_funcao(categoria: str | None, funcao: str | None) -> str | None:
+	"""Deriva o Role Profile a partir da categoria/função do associado.
+
+	Retorna `None` quando não há mapeamento definido. Nesse caso o perfil atual
+	do usuário **não deve ser alterado** automaticamente, sob risco de remover
+	acessos já concedidos.
+	"""
+	categoria = (categoria or "").strip()
+	funcao = (funcao or "").strip()
+
+	if categoria == "Beneficiário":
+		return "Beneficiário"
+
+	if categoria == "Dirigente":
+		if funcao in ("Comissão Fiscal",):
+			return funcao
+		return "Dirigente"
+
+	if categoria == "Escotista" and funcao in ("Assistente", "Chefe de Seção"):
+		return funcao
+
+	return None
+
+
 def _define_role_profile(associate):
-	# if beneficiary
-	role_profile = "Guest"
-	if associate.categoria == "Beneficiário":
-		role_profile = "Beneficiário"
-
-	if associate.categoria == "Dirigente":
-		if associate.funcao in ["Comissão Fiscal"]:
-			role_profile = associate.funcao
-
-		role_profile = "Dirigente"
-
-	if associate.categoria == "Escotista":
-		if associate.funcao in ["Assistente", "Chefe de Seção"]:
-			role_profile = associate.funcao
-
-	return role_profile
+	return _define_role_profile_por_funcao(
+		getattr(associate, "categoria", None), getattr(associate, "funcao", None)
+	)
 
 
 @frappe.whitelist()
@@ -140,7 +153,9 @@ def create_associate_user(associate=None, associate_name=None, force=False):
 		)
 		return
 
-	role_profile = _define_role_profile(associate)
+	# Na criação, a ausência de mapeamento vira perfil sem acesso (Guest):
+	# o usuário nasce sem papéis e recebe acesso por concessão explícita.
+	role_profile = _define_role_profile(associate) or PERFIL_SEM_ACESSO
 
 	if associate.registro and associate.id_escoteiros:
 		registro = associate.registro.split("-")[0]
@@ -274,18 +289,68 @@ def create_associate_user_manually(associate_name):
 def activate_associate_user(associate):
 	user_doc = frappe.get_doc("User", associate.id_escoteiros)
 	user_doc.enabled = 1
-	user_doc.save()
+	# Gravar o usuário faz o Frappe recalcular os papéis a partir do perfil;
+	# preservamos as concessões manuais.
+	save_user_preserving_roles(user_doc)
 
 
 @frappe.whitelist()
 def deactivate_associate_user(user):
 	user_doc = frappe.get_doc("User", user.name)
 	user_doc.enabled = 0
-	user_doc.save()
+	save_user_preserving_roles(user_doc)
+
+
+def _sync_role_profile(user, associate, old_categoria=None, old_funcao=None, log=None):
+	"""Sincroniza o Role Profile do usuário após mudança de função/categoria.
+
+	Regra: a automação só substitui um perfil que ela mesma teria atribuído.
+	Se o usuário está num perfil diferente do derivado da função/categoria
+	anterior (ex.: "Diretoria Eleita" ou "Gestor Financeiro" definidos
+	manualmente), o perfil é mantido — gravar `role_profile_name` zeraria todos
+	os papéis do usuário e removeria acessos concedidos fora da automação.
+	"""
+	log = log or _logger()
+
+	perfil_novo = _define_role_profile(associate)
+	if not perfil_novo:
+		log.info(
+			f"[UPDATE] skip role profile associate_name={associate.name} "
+			f"reason=sem mapeamento para categoria='{associate.categoria}' funcao='{associate.funcao}'"
+		)
+		return
+
+	perfil_atual = user.role_profile_name
+	if perfil_atual == perfil_novo:
+		return
+
+	perfil_anterior_derivado = _define_role_profile_por_funcao(old_categoria, old_funcao)
+	perfil_gerenciado_pela_automacao = perfil_atual in (None, "", PERFIL_SEM_ACESSO, perfil_anterior_derivado)
+
+	if not perfil_gerenciado_pela_automacao:
+		log.info(
+			f"[UPDATE] skip role profile associate_name={associate.name} "
+			f"reason=perfil '{perfil_atual}' definido manualmente (derivado seria '{perfil_novo}')"
+		)
+		return
+
+	resultado = apply_role_profile(user, perfil_novo)
+	log.info(
+		f"[UPDATE] role profile associate_name={associate.name} "
+		f"'{resultado['perfil_anterior']}' -> '{resultado['perfil_novo']}' "
+		f"papeis_preservados={resultado['papeis_preservados']}"
+	)
 
 
 @frappe.whitelist()
-def update_associate_user(associate_name, old_funcao_categoria=None, new_funcao_categoria=None, **_kwargs):
+def update_associate_user(
+	associate_name,
+	old_funcao_categoria=None,
+	new_funcao_categoria=None,
+	old_categoria=None,
+	old_funcao=None,
+	**_kwargs,
+):
 	log = _logger()
 	if not _should_auto_create_users():
 		log.info(f"[UPDATE] skip associate_name={associate_name} reason=auto create disabled")
@@ -315,10 +380,9 @@ def update_associate_user(associate_name, old_funcao_categoria=None, new_funcao_
 
 		# Atualizar role profile se mudou função/categoria
 		if old_funcao_categoria != new_funcao_categoria:
-			role_profile = _define_role_profile(associate)
-			if role_profile and user.role_profile_name != role_profile:
-				user.role_profile_name = role_profile
-				user.save(ignore_permissions=True)
+			# Recarrega o usuário: activate/deactivate acima gravam o documento.
+			user = _get_user(associate.id_escoteiros) or user
+			_sync_role_profile(user, associate, old_categoria, old_funcao, log)
 
 		log.info(f"[UPDATE] done associate_name={associate_name}")
 

--- a/gris/gris/doctype/associado/associado.py
+++ b/gris/gris/doctype/associado/associado.py
@@ -175,6 +175,10 @@ class Associado(Document):
 		new_funcao_categoria = f"{self.funcao} - {self.categoria}" if self.funcao and self.categoria else None
 		self.flags.old_funcao_categoria = old_funcao_categoria
 		self.flags.new_funcao_categoria = new_funcao_categoria
+		# Guardados separadamente para que a sincronização de papéis saiba qual
+		# perfil a automação teria atribuído antes da alteração.
+		self.flags.old_categoria = getattr(old_doc, "categoria", None) if old_doc else None
+		self.flags.old_funcao = getattr(old_doc, "funcao", None) if old_doc else None
 		self.flags.old_status_no_grupo = getattr(old_doc, "status_no_grupo", None) if old_doc else None
 		self.flags.status_no_grupo_changed = self.flags.old_status_no_grupo != self.status_no_grupo
 
@@ -221,9 +225,10 @@ class Associado(Document):
 			job_name=f"update_associate_user:{self.name}",
 			queue="default",
 			associate_name=self.name,
-			# old_funcao_categoria=getattr(self.flags, "old_funcao_categoria", None),
 			old_funcao_categoria=getattr(self.flags, "old_funcao_categoria", None),
 			new_funcao_categoria=getattr(self.flags, "new_funcao_categoria", None),
+			old_categoria=getattr(self.flags, "old_categoria", None),
+			old_funcao=getattr(self.flags, "old_funcao", None),
 			enqueue_after_commit=True,
 		)
 		# Se houve alteração no histórico, atualiza série temporal de associados

--- a/gris/patches/add_project_roles_to_all_users.py
+++ b/gris/patches/add_project_roles_to_all_users.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import frappe
 
+from gris.api.users.roles import add_user_roles
+
 PROJECT_ROLES = ("Visualizador de projetos", "Editor de projetos")
 EXCLUDED_USERS = ("Guest",)
 
@@ -30,4 +32,7 @@ def execute():
 		if not roles_to_add:
 			continue
 
-		frappe.get_doc("User", user_name).add_roles(*roles_to_add)
+		# add_roles() grava o usuário e faz o Frappe repopular a lista de papéis a
+		# partir do Role Profile, removendo concessões manuais. Concedemos de
+		# forma aditiva.
+		add_user_roles(user_name, roles_to_add)

--- a/gris/tests/test_roles_importacao_associados.py
+++ b/gris/tests/test_roles_importacao_associados.py
@@ -1,0 +1,173 @@
+"""Testes da preservação de papéis (roles) durante a importação de associados.
+
+Cenários cobertos:
+1. Papel concedido manualmente sobrevive a `User.save()` automático
+2. Concessão do papel Responsavel na importação não zera papéis existentes
+3. Troca automática de perfil preserva papéis concedidos manualmente
+4. Perfil definido manualmente não é rebaixado pela automação
+5. Categoria/função sem mapeamento não altera o perfil do usuário
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from gris.api.associate.importer import _upsert_portal_user
+from gris.api.users.roles import (
+	add_user_roles,
+	apply_role_profile,
+	get_user_roles,
+	save_user_preserving_roles,
+)
+from gris.api.users.user_manager import _define_role_profile_por_funcao, _sync_role_profile
+
+EMAIL_TESTE = "teste.papeis.import@example.com"
+PAPEL_MANUAL = "Visualizador Calendario"
+PAPEL_EXTRA = "Responsavel"
+
+
+class _AssociadoFake:
+	"""Stub mínimo com os campos usados pela sincronização de papéis."""
+
+	def __init__(self, name, categoria=None, funcao=None):
+		self.name = name
+		self.categoria = categoria
+		self.funcao = funcao
+
+
+def _criar_usuario(role_profile=None) -> "frappe.Document":
+	if frappe.db.exists("User", EMAIL_TESTE):
+		frappe.delete_doc("User", EMAIL_TESTE, ignore_permissions=True, force=True)
+
+	user = frappe.get_doc(
+		{
+			"doctype": "User",
+			"email": EMAIL_TESTE,
+			"first_name": "Teste",
+			"last_name": "Papeis",
+			"send_welcome_email": 0,
+			"enabled": 1,
+			"role_profile_name": role_profile,
+		}
+	)
+	user.insert(ignore_permissions=True)
+	return user
+
+
+class TestPapeisImportacaoAssociados(FrappeTestCase):
+	def setUp(self):
+		self._cleanup()
+
+	def tearDown(self):
+		self._cleanup()
+
+	def _cleanup(self):
+		if frappe.db.exists("User", EMAIL_TESTE):
+			frappe.delete_doc("User", EMAIL_TESTE, ignore_permissions=True, force=True)
+		frappe.db.commit()
+
+	def test_01_save_preserva_papel_concedido_manualmente(self):
+		"""Gravar o usuário não pode remover papéis fora do Role Profile."""
+		user = _criar_usuario(role_profile="Beneficiário")
+		add_user_roles(EMAIL_TESTE, [PAPEL_MANUAL, PAPEL_EXTRA])
+		self.assertIn(PAPEL_EXTRA, get_user_roles(EMAIL_TESTE))
+
+		user = frappe.get_doc("User", EMAIL_TESTE)
+		user.enabled = 0
+		save_user_preserving_roles(user)
+
+		papeis = get_user_roles(EMAIL_TESTE)
+		self.assertIn(PAPEL_EXTRA, papeis)
+		self.assertIn(PAPEL_MANUAL, papeis)
+
+	def test_02_importacao_nao_zera_papeis_de_usuario_existente(self):
+		"""Conceder Responsavel na importação mantém os demais papéis."""
+		_criar_usuario(role_profile="Dirigente")
+		papeis_antes = get_user_roles(EMAIL_TESTE)
+		self.assertTrue(papeis_antes, "perfil Dirigente deveria conceder papéis")
+
+		acao = _upsert_portal_user(
+			EMAIL_TESTE,
+			"Teste Papeis",
+			_AssociadoFake("ASSOC-TESTE"),
+			responsavel_name="responsavel-inexistente-teste",
+		)
+		self.assertEqual(acao, "skipped")
+
+		papeis_depois = get_user_roles(EMAIL_TESTE)
+		self.assertIn(PAPEL_EXTRA, papeis_depois, "papel Responsavel deveria ser concedido")
+		self.assertTrue(
+			papeis_antes.issubset(papeis_depois),
+			"papéis do perfil existente não podem ser removidos pela importação",
+		)
+		self.assertEqual(
+			frappe.db.get_value("User", EMAIL_TESTE, "role_profile_name"),
+			"Dirigente",
+			"a importação não deve trocar o perfil de um usuário existente",
+		)
+
+	def test_03_troca_de_perfil_preserva_papeis_manuais(self):
+		"""Ao trocar o perfil, papéis fora do perfil anterior são reaplicados."""
+		_criar_usuario(role_profile="Beneficiário")
+		add_user_roles(EMAIL_TESTE, [PAPEL_EXTRA])
+
+		resultado = apply_role_profile(frappe.get_doc("User", EMAIL_TESTE), "Dirigente")
+
+		papeis = get_user_roles(EMAIL_TESTE)
+		self.assertEqual(resultado["perfil_novo"], "Dirigente")
+		self.assertIn(PAPEL_EXTRA, papeis)
+		self.assertIn("Visualizador Associados", papeis)
+
+	def test_04_perfil_manual_nao_e_rebaixado(self):
+		"""Perfil definido manualmente não é substituído pelo derivado."""
+		_criar_usuario(role_profile="Diretoria Eleita")
+		papeis_antes = get_user_roles(EMAIL_TESTE)
+
+		associado = _AssociadoFake("ASSOC-TESTE", categoria="Dirigente", funcao="Diretor Administrativo")
+		_sync_role_profile(
+			frappe.get_doc("User", EMAIL_TESTE),
+			associado,
+			old_categoria="Dirigente",
+			old_funcao="Diretor Presidente",
+		)
+
+		self.assertEqual(frappe.db.get_value("User", EMAIL_TESTE, "role_profile_name"), "Diretoria Eleita")
+		self.assertEqual(get_user_roles(EMAIL_TESTE), papeis_antes)
+
+	def test_05_categoria_sem_mapeamento_mantem_perfil(self):
+		"""Categoria sem mapeamento não pode rebaixar o usuário para Guest."""
+		self.assertIsNone(_define_role_profile_por_funcao("Colaboradores", ""))
+		self.assertIsNone(_define_role_profile_por_funcao("Escotista", "Diretor de Métodos"))
+		self.assertEqual(_define_role_profile_por_funcao("Dirigente", "Comissão Fiscal"), "Comissão Fiscal")
+		self.assertEqual(_define_role_profile_por_funcao("Escotista", "Chefe de Seção"), "Chefe de Seção")
+
+		_criar_usuario(role_profile="Chefe de Seção")
+		papeis_antes = get_user_roles(EMAIL_TESTE)
+
+		associado = _AssociadoFake("ASSOC-TESTE", categoria="Colaboradores", funcao="Apoio")
+		_sync_role_profile(
+			frappe.get_doc("User", EMAIL_TESTE),
+			associado,
+			old_categoria="Escotista",
+			old_funcao="Chefe de Seção",
+		)
+
+		self.assertEqual(frappe.db.get_value("User", EMAIL_TESTE, "role_profile_name"), "Chefe de Seção")
+		self.assertEqual(get_user_roles(EMAIL_TESTE), papeis_antes)
+
+	def test_06_perfil_gerenciado_pela_automacao_e_atualizado(self):
+		"""Quando o perfil atual é o derivado da função anterior, a troca ocorre."""
+		_criar_usuario(role_profile="Assistente")
+		add_user_roles(EMAIL_TESTE, [PAPEL_EXTRA])
+
+		associado = _AssociadoFake("ASSOC-TESTE", categoria="Escotista", funcao="Chefe de Seção")
+		_sync_role_profile(
+			frappe.get_doc("User", EMAIL_TESTE),
+			associado,
+			old_categoria="Escotista",
+			old_funcao="Assistente",
+		)
+
+		papeis = get_user_roles(EMAIL_TESTE)
+		self.assertEqual(frappe.db.get_value("User", EMAIL_TESTE, "role_profile_name"), "Chefe de Seção")
+		self.assertIn("Gestor de Associados", papeis)
+		self.assertIn(PAPEL_EXTRA, papeis, "papel manual deve sobreviver à troca de perfil")


### PR DESCRIPTION
Usuários relatavam perda de acesso (roles) após a importação de associados por arquivo. A causa é o comportamento do Frappe: gravar `User.role_profile_name` — e qualquer `User.save()` em um usuário que tenha perfil — faz o framework limpar e repopular a lista de papéis a partir do Role Profile, descartando papéis concedidos manualmente.

Três caminhos disparavam isso durante a importação:

1. `update_associate_user` sobrescrevia o perfil sempre que função/categoria mudavam. Como `_define_role_profile` devolvia "Guest" (perfil sem nenhum papel) para todas as categorias não mapeadas — Contribuinte, Colaboradores, Pais/Responsáveis, Escotista sem função mapeada etc. — o usuário ficava sem acesso algum. Perfis definidos manualmente (Diretoria Eleita, Gestor Financeiro) também eram rebaixados para o perfil derivado.
2. `activate/deactivate_associate_user` gravavam o usuário para alternar `enabled`, recalculando os papéis como efeito colateral.
3. `_upsert_portal_user` concedia o papel Responsavel via `User.save()`, o que zerava os demais papéis do usuário no mesmo save.

Mudanças:

- Novo módulo `gris/api/users/roles.py` com concessão aditiva de papéis (grava `Has Role` diretamente, sem `User.save()`), gravação preservando papéis manuais e troca de perfil que reaplica as concessões manuais.
- `_define_role_profile` devolve `None` quando não há mapeamento; na criação de usuário isso vira "Guest" (comportamento atual), mas na atualização o perfil existente é mantido. Corrige também o mapeamento de Comissão Fiscal, que era sobrescrito por Dirigente.
- A automação só substitui um perfil que ela mesma teria atribuído: o perfil derivado da função/categoria anterior é comparado com o perfil atual, e perfis definidos manualmente são preservados.
- `_upsert_portal_user`, activate/deactivate e o patch de papéis de projetos passam a usar os utilitários aditivos.
- `diagnosticar_papeis_removidos` (System Manager, simulação por padrão) lista pelo histórico de versões os papéis retirados automaticamente e pode restaurá-los.
- Testes cobrindo preservação de papéis, não rebaixamento de perfil manual e categoria sem mapeamento.


Claude-Session: https://claude.ai/code/session_01NRJdmXaGys3U9p3j3nh4qK